### PR TITLE
More fixes for TS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ clean:
 distclean: clean
 	./rebar delete-deps
 
+testclean: clean
+	@rm -rf eunit.log .eunit/*
+
+test: testclean compile
+	./rebar eunit skip_deps=true
+
 DIALYZER_APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
 	xmerl webtool snmp public_key mnesia eunit syntax_tools compiler
 

--- a/include/riak_ql_ddl.hrl
+++ b/include/riak_ql_ddl.hrl
@@ -32,26 +32,23 @@
 -type complex_field_type() :: {map, [#riak_field_v1{}]} | any.
 
 -record(param_v1, {
-          name :: string()
-         }).
+	  name :: string()
+	 }).
 
 -record(hash_fn_v1, {
-	      mod       :: atom(),
-          fn        :: atom(),
-          args = [] :: [#param_v1{} | any()]
-         }).
+	  mod       :: atom(),
+	  fn        :: atom(),
+	  args = [] :: [#param_v1{} | any()],
+	  type      :: field_type()
+	 }).
 
--record(partition_key_v1, {
-          ast = [] :: [#hash_fn_v1{} | #param_v1{}]
-         }).
-
--record(local_key_v1, {
-          ast = [] :: [#hash_fn_v1{} | #param_v1{}]
-         }).
+-record(key_v1, {
+	  ast = [] :: [#hash_fn_v1{} | #param_v1{}]
+	 }).
 
 -record(ddl_v1, {
           bucket             :: binary(),
           fields        = [] :: [#riak_field_v1{}],
-          partition_key      :: none | #partition_key_v1{},
-          local_key          :: #local_key_v1{}
+          partition_key      :: #key_v1{} | none,
+          local_key          :: #key_v1{}
          }).

--- a/include/riak_ql_sql.hrl
+++ b/include/riak_ql_sql.hrl
@@ -9,10 +9,13 @@
 -record(riak_sql_v1,
 	{
 	  'SELECT'      = []    :: [selection() | operator() | combinator()],
-	  'FROM'        = <<>>  :: binary(),     % TODO fix up
+	  'FROM'        = <<>>  :: binary() | {list, [binary()]} | {regex, list()},
 	  'WHERE'       = []    :: [filter()],
 	  'ORDER BY'    = []    :: [sorter],
 	  'LIMIT'       = []    :: [limit()],
+	  helper_mod            :: atom(),
 	  partition_key = none  :: none | binary(),
-	  is_executable = false :: boolean()
+	  is_executable = false :: boolean(),
+	  type          = sql   :: sql | timeseries,
+	  local_key                                  % prolly a mistake to put this here - should be in DDL
 	}).

--- a/src/riak_ql.xrl.tests
+++ b/src/riak_ql.xrl.tests
@@ -167,10 +167,10 @@ not_a_date_test_() ->
                ],
     ?_assertEqual(Expected, Got).
 
-quote_1_test_() ->
-    Got = riak_ql_lexer:get_tokens("\" yardle hoop !@#$%^&*() \""),
+double_quote_1_test_() ->
+    Got = riak_ql_lexer:get_tokens("\" yardle hoop !@#$%^&*() _ -\""),
     Expected = [
-                {quoted, "yardle hoop !@#$%^&*()"}
+                {quoted, "yardle hoop !@#$%^&*() _ -"}
                ],
     ?_assertEqual(Expected, Got).
 
@@ -243,7 +243,7 @@ timeseries_test_() ->
 				   ++ "user varchar not_null, "
 				   ++ "time timestamp not_null, "
 				   ++ "weather varchar not_null, "
-				   ++ "temperature varchar not_null, "
+				   ++ "temperature float not_null, "
 				   ++ "PRIMARY KEY ((geohash, quantum(time, 15, m), time, user)"),
     Expected = [
                 {create_table, "CREATE TABLE"},
@@ -266,7 +266,7 @@ timeseries_test_() ->
 		{chars, "not_null"},
 		{comma, ","},
 		{chars, "temperature"},
-		{varchar, "varchar"},
+		{float, "float"},
 		{chars, "not_null"},
 		{comma, ","},
 		{primary_key, "PRIMARY KEY"},

--- a/src/riak_ql.xrl.tests
+++ b/src/riak_ql.xrl.tests
@@ -287,7 +287,7 @@ timeseries_test_() ->
 		{chars, "not_null"},
 		{comma, ","},
 		{chars, "temperature"},
-		{float, "float"},
+		{float_type, "float"},
 		{chars, "not_null"},
 		{comma, ","},
 		{primary_key, "PRIMARY KEY"},

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -2,292 +2,548 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(sql_test(String, Expected),
+	Exp2 = fix(Expected),
 	Toks = riak_ql_lexer:get_tokens(String),
 	{ok, Got} = parse(Toks),
+	?assertEqual(Exp2, Got)).
+
+-define(where_test(Uncanonical, Expected), 
+	Got = canonicalise(Uncanonical),
 	?assertEqual(Expected, Got)).
+
+fix(#riak_sql_v1{'FROM' = F} = Expected) ->
+    case F of
+	{regex, _} -> Expected;
+	{list,  _} -> Expected;
+	_          -> Mod = riak_ql_ddl:make_module_name(F),
+		      Expected#riak_sql_v1{helper_mod = Mod}
+    end;
+fix(Other) ->
+    Other.
 
 %% Tests
 select_sql_test() ->
     ?sql_test("select * from argle",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"argle">>}).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"argle">>}).
 
 select_quoted_sql_test() ->
     ?sql_test("select * from \"argle\"",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"argle">>}).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"argle">>}).
 
 select_quoted_keyword_sql_test() ->
     ?sql_test("select * from \"select\"",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"select">>}).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"select">>}).
 
 select_nested_quotes_sql_test() ->
     ?sql_test("select * from \"some \"quotes\" in me\"",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"some \"quotes\" in me">>}).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"some \"quotes\" in me">>}).
 
 select_regex_sql_test() ->
     ?sql_test("select * from /.*/",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = {regex, "/.*/"}}).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = {regex, "/.*/"}}).
 
 select_with_limit_sql_test() ->
     ?sql_test("select * from /.*/ limit 1",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = {regex, "/.*/"},
-		     'LIMIT'  = 1}).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = {regex, "/.*/"},
+			   'LIMIT'  = 1}).
 
 select_from_lists_sql_test() ->
     ?sql_test("select * from events, errors",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = {list, [<<"events">>, <<"errors">>]}
-		    }).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = {list, [<<"events">>, <<"errors">>]}
+			  }).
 
 select_fields_from_lists_sql_test() ->
     ?sql_test("select hip, hop, dont, stop from events",
-	#riak_sql_v1{'SELECT' = [["hip"], ["hop"], ["dont"], ["stop"]],
-		     'FROM'   = <<"events">>
-		    }).
+	      #riak_sql_v1{'SELECT' = [["hip"], ["hop"], ["dont"], ["stop"]],
+			   'FROM'   = <<"events">>
+			  }).
 
 select_where_1_sql_test() ->
     ?sql_test("select value from response_times " ++
-	    "where time > '2013-08-12 23:32:01' and time < '2013-08-13 12:34:56'",
-	#riak_sql_v1{'SELECT' = [["value"]],
-		     'FROM'   = <<"response_times">>,
-		     'WHERE'  = [
-				 {and_,
-				  {'>', "time", {datetime, {{2013, 8, 12}, {23, 32, 1}}}},
-				  {'<', "time", {datetime, {{2013, 8, 13}, {12, 34, 56}}}}
-				 }
-				]
-		    }).
+		  "where time > '2013-08-12 23:32:01' and time < '2013-08-13 12:34:56'",
+	      #riak_sql_v1{'SELECT' = [["value"]],
+			   'FROM'   = <<"response_times">>,
+			   'WHERE'  = [
+				       {and_,
+					{'<', "time", {datetime, {{2013, 8, 13}, {12, 34, 56}}}},
+					{'>', "time", {datetime, {{2013, 8, 12}, {23, 32, 1}}}}
+				       }
+				      ]
+			  }).
 
 select_where_2_sql_test() ->
     ?sql_test("select value from response_times where time > now() - 1h limit 1000",
-	#riak_sql_v1{'SELECT' = [["value"]],
-		     'FROM'   = <<"response_times">>,
-		     'WHERE'  = [
-				 {'>', "time", {'-', {"now", []}, {int, 3600}}}
-				],
-		     'LIMIT'  = 1000
-		    }).
+	      #riak_sql_v1{'SELECT' = [["value"]],
+			   'FROM'   = <<"response_times">>,
+			   'WHERE'  = [
+				       {'>', "time", {'-', {"now", []}, {int, 3600}}}
+				      ],
+			   'LIMIT'  = 1000
+			  }).
 
 select_where_3_sql_test() ->
     ?sql_test("select value from response_times where time > 1388534400",
-	#riak_sql_v1{'SELECT' = [["value"]],
-		     'FROM'   = <<"response_times">>,
-		     'WHERE'  = [
-				 {'>', "time", {int, 1388534400}}
-				]
-		    }).
+	      #riak_sql_v1{'SELECT' = [["value"]],
+			   'FROM'   = <<"response_times">>,
+			   'WHERE'  = [
+				       {'>', "time", {int, 1388534400}}
+				      ]
+			  }).
 
 select_where_4_sql_test() ->
     ?sql_test("select value from response_times where time > 1388534400s",
-	#riak_sql_v1{'SELECT' = [["value"]],
-		     'FROM'   = <<"response_times">>,
-		     'WHERE'  = [
-				 {'>', "time", {int, 1388534400}}
-				]
-		    }).
+	      #riak_sql_v1{'SELECT' = [["value"]],
+			   'FROM'   = <<"response_times">>,
+			   'WHERE'  = [
+				       {'>', "time", {int, 1388534400}}
+				      ]
+			  }).
 
 select_where_5_sql_test() ->
     ?sql_test("select * from events where time = 1400497861762723 "++
-	    "and sequence_number = 2321",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"events">>,
-		     'WHERE'  = [
-				 {and_, 
-				  {'=', "time",            {int, 1400497861762723}},
-				  {'=', "sequence_number", {int, 2321}}
-				 }
-				]
-		    }).
+		  "and sequence_number = 2321",
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"events">>,
+			   'WHERE'  = [
+				       {and_, 
+					{'=', "sequence_number", {int, 2321}},
+					{'=', "time",            {int, 1400497861762723}}
+				       }
+				      ]
+			  }).
 
 select_where_6_sql_test() ->
     ?sql_test("select * from /^stats\./i where time > now() - 1h",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = {regex, "/^stats\./i"},
-		     'WHERE'  = [
-				 {'>', "time", {'-', {"now", []}, {int, 3600}}}
-				]
-		    }).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = {regex, "/^stats\./i"},
+			   'WHERE'  = [
+				       {'>', "time", {'-', {"now", []}, {int, 3600}}}
+				      ]
+			  }).
 
 select_where_7_sql_test() ->
     ?sql_test("select * from /.*/ limit 1",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = {regex, "/.*/"},
-		     'LIMIT'  = 1
-		    }).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = {regex, "/.*/"},
+			   'LIMIT'  = 1
+			  }).
 
 select_where_8_sql_test() ->
     ?sql_test("select * from events where state = 'NY'",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"events">>,
-		     'WHERE'  = [
-				 {'=', "state", {word, "NY"}}
-				]
-		    }).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"events">>,
+			   'WHERE'  = [
+				       {'=', "state", {word, "NY"}}
+				      ]
+			  }).
 
 select_where_9_sql_test() ->
     ?sql_test("select * from log_lines where line =~ /error/i",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"log_lines">>,
-		     'WHERE'  = [
-				 {'=~', "line", {regex, "/error/i"}}
-				]
-		    }).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"log_lines">>,
+			   'WHERE'  = [
+				       {'=~', "line", {regex, "/error/i"}}
+				      ]
+			  }).
 
 select_where_10_sql_test() ->
-    ?sql_test("select * from events where customer_id = 23 and type = 'click'",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"events">>,
-		     'WHERE'  = [
-				 {and_, 
-				  {'=', "customer_id", {int,  23}},
-				  {'=', "type",        {word, "click"}}
-				 }
-				]
-		    }).
+    ?sql_test("select * from events where customer_id = 23 and type = 'click10'",
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"events">>,
+			   'WHERE'  = [
+				       {and_, 
+					{'=', "customer_id", {int,  23}},
+					{'=', "type",        {word, "click10"}}
+				       }
+				      ]
+			  }).
 
 select_where_11_sql_test() ->
     ?sql_test("select * from response_times where value > 500",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"response_times">>,
-		     'WHERE'  = [
-				 {'>', "value", {int, 500}}
-				]
-		    }).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"response_times">>,
+			   'WHERE'  = [
+				       {'>', "value", {int, 500}}
+				      ]
+			  }).
 
 select_where_12_sql_test() ->
     ?sql_test("select * from events where email !~ /.*gmail.*/",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"events">>,
-		     'WHERE'  = [
-				 {'!~', "email", {regex, "/.*gmail.*/"}}
-				]
-				}).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"events">>,
+			   'WHERE'  = [
+				       {'!~', "email", {regex, "/.*gmail.*/"}}
+				      ]
+			  }).
 
 select_where_13_sql_test() ->
     ?sql_test("select * from nagios_checks where status <> 0",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"nagios_checks">>,
-		     'WHERE'  = [
-				 {'<>', "status", {int, 0}}
-				]
-		    }).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"nagios_checks">>,
+			   'WHERE'  = [
+				       {'<>', "status", {int, 0}}
+				      ]
+			  }).
 
 select_where_14_sql_test() ->
     ?sql_test("select * from events where signed_in = false",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"events">>,
-		     'WHERE'  = [
-				 {'=', "signed_in", {word, "false"}}
-				]
-		    }).
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"events">>,
+			   'WHERE'  = [
+				       {'=', "signed_in", {word, "false"}}
+				      ]
+			  }).
 
 select_where_15_sql_test() ->
     ?sql_test("select * from events where (email =~ /.*gmail.*/ or " ++
-	    "email =~ /.*yahoo.*/) and state = 'ny'",
-	#riak_sql_v1{'SELECT' = [["*"]],
-		     'FROM'   = <<"events">>,
-		     'WHERE'  = [
-				 {and_,
-				  {or_,
-				   {'=~', "email", {regex, "/.*gmail.*/"}},
-				   {'=~', "email", {regex, "/.*yahoo.*/"}}
-				  },
-				  {'=', "state", {word, "ny"}}
-				 }
-				]
-		    }).
+		  "email =~ /.*yahoo.*/) and state = 'ny'",
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"events">>,
+			   'WHERE'  = [
+				       {and_,
+					{'=', "state", {word, "ny"}},
+					{or_,
+					 {'=~', "email", {regex, "/.*gmail.*/"}},
+					 {'=~', "email", {regex, "/.*yahoo.*/"}}
+					}
+				       }
+				      ]
+			  }).
+
+select_where_letters_nos_in_strings_1a_test() ->
+    ?sql_test("select * from events where user = 'user 1'",
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"events">>,
+			   'WHERE'  = [
+				       {'=', "user", {word, "user 1"}}
+				      ]
+			  }).
+
+%% TODO
+%%
+%% Single quotes don't really work
+%%
+%% select_where_letters_nos_in_strings_2a_test() ->
+%%    ?sql_test("select weather from GeoCheckin where time > 2000 and time < 8000 and user = 'user_1'",
+%% 	      #riak_sql_v1{'SELECT' = [["weather"]],
+%% 			   'FROM'   = <<"GeoCheckin">>,
+%% 			   'WHERE'  = [
+%% 				       {and_,
+%% 					{and_,
+%% 					 {'>', "time", {int, 2000}},
+%% 					 {'<', "time", {int, 8000}}
+%% 					},
+%% 					{'=', "user", {word, "user_1"}}
+%% 					}
+%% 				      ]
+%% 			  }).
+
+select_where_letters_nos_in_strings_1b_test() ->
+    ?sql_test("select * from events where user = \"user 1\"",
+	      #riak_sql_v1{'SELECT' = [["*"]],
+			   'FROM'   = <<"events">>,
+			   'WHERE'  = [
+				       {'=', "user", {word, "user 1"}}
+				      ]
+			  }).
+
+select_where_letters_nos_in_strings_2b_test() ->
+    ?sql_test("select weather from GeoCheckin where time > 2000 and time < 8000 and user = \"user_1\"",
+	      #riak_sql_v1{'SELECT' = [["weather"]],
+			   'FROM'   = <<"GeoCheckin">>,
+			   'WHERE'  = [
+				       {and_,
+					{'=', "user", {word, "user_1"}},
+					{and_,
+					 {'<', "time", {int, 8000}},
+					 {'>', "time", {int, 2000}}
+					}
+				       }
+				      ]
+			  }).
+
+select_where_brackets_1_test() ->
+    ?sql_test("select weather from GeoCheckin where (time > 2000 and time < 8000) and user = \"user_1\"",
+	      #riak_sql_v1{'SELECT' = [["weather"]],
+			   'FROM'   = <<"GeoCheckin">>,
+			   'WHERE'  = [
+				       {and_,
+					{'=', "user", {word, "user_1"}},
+					{and_,
+					 {'<', "time", {int, 8000}},
+					 {'>', "time", {int, 2000}}
+					}
+				       }
+				      ]
+			  }).
+
+select_where_brackets_2_test() ->
+    ?sql_test("select weather from GeoCheckin where user = \"user_1\" and (time > 2000 and time < 8000)",
+	      #riak_sql_v1{'SELECT' = [["weather"]],
+			   'FROM'   = <<"GeoCheckin">>,
+			   'WHERE'  = [
+				       {and_,
+					{'=', "user", {word, "user_1"}},
+					{and_,
+					 {'<', "time", {int, 8000}},
+					 {'>', "time", {int, 2000}}
+					}
+				       }
+				      ]
+			  }).
+
+select_where_brackets_2a_test() ->
+    ?sql_test("select weather from GeoCheckin where user = \"user_1\" and (time > 2000 and (time < 8000))",
+	      #riak_sql_v1{'SELECT' = [["weather"]],
+			   'FROM'   = <<"GeoCheckin">>,
+			   'WHERE'  = [
+				       {and_,
+					{'=', "user", {word, "user_1"}},
+					{and_,
+					 {'<', "time", {int, 8000}},
+					 {'>', "time", {int, 2000}}
+					}
+				       }
+				      ]
+			  }).
+
+%%
+%% canonicalise WHERE clauses tests
+%%
+
+canonicalise_where_1_test() ->
+    ?where_test({or_, 
+		 {'<', "alpha", {int, 2}}, 
+		 {'>', "beta",  {int, 3}}
+		},
+		{or_, 
+		 {'<', "alpha", {int, 2}},
+		 {'>', "beta",  {int, 3}}
+		}).
+
+canonicalise_where_2_test() ->
+    ?where_test({or_, 
+		 {'>', "beta",  {int, 3}},
+		 {'<', "alpha", {int, 2}} 
+		},
+		{or_, 
+		 {'<', "alpha", {int, 2}},
+		 {'>', "beta",  {int, 3}}
+		}).
+
+canonicalise_where_3_test() ->
+    ?where_test({and_, 
+		 {'>', "beta",  {int, 3}},
+		 {'<', "alpha", {int, 2}} 
+		},
+		{and_, 
+		 {'<', "alpha", {int, 2}},
+		 {'>', "beta",  {int, 3}}
+		}).
+
+canonicalise_where_4_test() ->
+    ?where_test({or_, 
+		 {and_, 
+		  {'>', "beta",  {int, 3}},
+		  {'<', "alpha", {int, 2}} 
+		 },
+		 {'=', "time", {int, 1234}}
+		},
+		{or_,
+		 {'=', "time", {int, 1234}},
+		 {and_, 
+		  {'<', "alpha", {int, 2}},
+		  {'>', "beta",  {int, 3}}
+		 }
+		}).
+
+%%
+%% these are the ones that matters
+%% all the ands float to the front which means
+%% the query rewriter can walk them them and rearange them
+%%
+canonicalise_where_5_test() ->
+    ?where_test({and_, 
+		 {or_, 
+		  {'>', "beta",  {int, 3}},
+		  {'<', "alpha", {int, 2}} 
+		 },
+		 {and_, 
+		  {'>', "gamma", {int, 3}},
+		  {'<', "delta", {int, 2}} 
+		 }
+		},
+		{and_, 
+		 {'<', "delta", {int, 2}},
+		 {and_, 
+		  {'>', "gamma", {int, 3}},
+		  {or_, 
+		   {'<', "alpha", {int, 2}},
+		   {'>', "beta",  {int, 3}}
+		  }
+		 }
+		}).
+
+canonicalise_where_6_test() ->
+    ?where_test({and_, 
+		 {and_, 
+		  {'>', "beta6",  {int, 3}},
+		  {'<', "alpha6", {int, 2}} 
+		 },
+		 {and_, 
+		  {'>', "gamma6", {int, 3}},
+		  {'<', "delta6", {int, 2}} 
+		 }
+		},
+		{and_, 
+		 {'<', "alpha6", {int, 2}},
+		 {and_, 
+		  {'<', "delta6", {int, 2}},
+		  {and_, 
+		   {'>', "beta6",  {int, 3}},
+		   {'>', "gamma6", {int, 3}}
+		  }
+		 }
+		}).
+
+canonicalise_where_7_test() ->
+    ?where_test({and_, 
+		 {and_, 
+		  {or_, 
+		   {'>', "beta7",  {int, 3}},
+		   {'<', "alpha7", {int, 2}} 
+		  },
+		  {and_, 
+		   {'>', "gamma7", {int, 3}},
+		   {'<', "delta7", {int, 2}} 
+		  }
+		 },
+		 {and_, 
+		  {'>', "epsilon7", {int, 3}},
+		  {'<', "zeta7",    {int, 2}} 
+		 }
+		},
+		{and_, 
+		 {'<', "delta7", {int, 2}},
+		 {and_, 
+		  {'<', "zeta7", {int, 2}},
+		  {and_,
+		   {'>', "epsilon7", {int, 3}},
+		   {and_, 
+		    {'>', "gamma7", {int, 3}},
+		    {or_, 
+		     {'<', "alpha7", {int, 2}},
+		     {'>', "beta7",  {int, 3}}
+		    }
+		   }
+		  }
+		 }
+		}).
+
+%%
+%% create table tests
+%%
 
 create_simple_sql_test() ->
     ?sql_test("create table temperatures " ++
-	    "(time timestamp not null, " ++
-	    "temperature_k float, " ++
-	    "primary key (time))",
-	#ddl_v1{
-	   bucket = <<"temperatures">>,
-	   fields = [
-		     #riak_field_v1{
-			name = "time",
-			position = 1,
-			type = timestamp,
-			optional = false},
-		     #riak_field_v1{
-			name = "temperature_k",
-			position = 2,
-			type = float,
-			optional = true}
-		    ],	
-	   partition_key = none,
-	   local_key = #local_key_v1{
-			  ast = [#param_v1{
-				    name = ["time"]
-				   }]
-			 }
-	  }).
+		  "(time timestamp not null, " ++
+		  "temperature_k float, " ++
+		  "primary key (time))",
+	      #ddl_v1{
+		 bucket = <<"temperatures">>,
+		 fields = [
+			   #riak_field_v1{
+			      name = "time",
+			      position = 1,
+			      type = timestamp,
+			      optional = false},
+			   #riak_field_v1{
+			      name = "temperature_k",
+			      position = 2,
+			      type = float,
+			      optional = true}
+			  ],	
+		 partition_key = #key_v1{
+				    ast = [#param_v1{
+					      name = ["time"]
+					     }]
+				   },
+		 local_key = #key_v1{
+				ast = [#param_v1{
+					  name = ["time"]
+					 }]
+			       }
+		}).
 
 create_composite_key_sql_test() ->
     ?sql_test("create table temperatures " ++
-	    "(time timestamp not null, " ++
-	    "user_id varchar not null, " ++
-	    "mytype varchar not null, " ++
-	    "primary key ((time, user_id), mytype))",
-	#ddl_v1{
-	   bucket = <<"temperatures">>,
-	   fields = [
-		     #riak_field_v1{
-			name = "time",
-			position = 1,
-			type = timestamp,
-			optional = false},
-		     #riak_field_v1{
-			name = "user_id",
-			position = 2,
-			type = binary,
-			optional = false},
-		     #riak_field_v1{
-			name = "mytype",
-			position = 3,
-			type = binary,
-			optional = false}
-		    ],
-	   partition_key = #partition_key_v1{
-			      ast = [#param_v1{
-					name = ["time"]
-				       },
-				     #param_v1{
-					name = ["user_id"]
-				       }]},
-	   local_key = #local_key_v1{
-			  ast = [#param_v1{
-				    name = ["mytype"]
-				   }
-				]}
-	  }).
+		  "(time timestamp not null, " ++
+		  "user_id varchar not null, " ++
+		  "mytype varchar not null, " ++
+		  "primary key ((time, user_id), mytype))",
+	      #ddl_v1{
+		 bucket = <<"temperatures">>,
+		 fields = [
+			   #riak_field_v1{
+			      name = "time",
+			      position = 1,
+			      type = timestamp,
+			      optional = false},
+			   #riak_field_v1{
+			      name = "user_id",
+			      position = 2,
+			      type = binary,
+			      optional = false},
+			   #riak_field_v1{
+			      name = "mytype",
+			      position = 3,
+			      type = binary,
+			      optional = false}
+			  ],
+		 partition_key = #key_v1{
+				    ast = [
+					   #param_v1{
+					      name = ["time"]
+					     },
+					   #param_v1{
+					      name = ["user_id"]
+					     }
+					  ]},
+		 local_key = #key_v1{
+				ast = [
+				       #param_v1{
+					  name = ["mytype"]
+					 }
+				      ]}
+		}).
 
 create_no_key_sql_test() ->
     ?sql_test("create table temperatures " ++
-	    "(time timestamp not null, " ++
-	    "temperature_k float)",
-	#ddl_v1{
-	   bucket = <<"temperatures">>,
-	   fields = [
-		     #riak_field_v1{
-			name = "time",
-			position = 1,
-			type = timestamp,
-			optional = false},
-		     #riak_field_v1{
-			name = "temperature_k",
-			position = 2,
-			type = float,
-			optional = true}],
-	   partition_key = none,
-	   local_key = none
-	  }).
+		  "(time timestamp not null, " ++
+		  "temperature_k float)",
+	      #ddl_v1{
+		 bucket = <<"temperatures">>,
+		 fields = [
+			   #riak_field_v1{
+			      name = "time",
+			      position = 1,
+			      type = timestamp,
+			      optional = false},
+			   #riak_field_v1{
+			      name = "temperature_k",
+			      position = 2,
+			      type = float,
+			      optional = true}],
+		 partition_key = none,
+		 local_key = none
+		}).
 
 %% need to refactor
 create_timeseries_sql_test() ->
@@ -332,25 +588,20 @@ create_timeseries_sql_test() ->
 			       type = binary,
 			       optional = true}
 			   ],
-		  partition_key = #partition_key_v1{
+		  partition_key = #key_v1{
 				     ast = [
-					    #param_v1{
-					       name = ["geohash"]
-					      },
-					    #hash_fn_v1{mod = riak_ql_quanta,
-							fn  = quantum,
-							args = [#param_v1{
-								   name = ["time"]
-								  }, 15, m]}
+					    #param_v1{name = ["geohash"]},
+					    #hash_fn_v1{mod  = riak_ql_quanta,
+							fn   = quantum,
+							args = [
+								#param_v1{name = ["time"]}, 15, m
+							       ],
+							type = timestamp}
 					   ]},
-		  local_key = #local_key_v1{
+		  local_key = #key_v1{
 				 ast = [
-					#param_v1{
-					   name = ["time"]
-					  },
-					#param_v1{
-					   name = ["user"]
-					  }
+					#param_v1{name = ["time"]},
+					#param_v1{name = ["user"]}
 				       ]}
 		 },
     ?assertEqual(Expected, Got).

--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -39,17 +39,18 @@
 -export([
 	 get_partition_key/2,
 	 get_local_key/2,
+	 make_key/3,
 	 is_valid_field/2,
 	 is_query_valid/2
 	]).
 
-%-ifdef(TEST).
+-ifdef(TEST).
 %% for debugging only
 -export([
 	 make_ddl/2,
 	 are_selections_valid/3
 	]).
-%-endif.
+-endif.
 
 -define(CANBEBLANK,  true).
 -define(CANTBEBLANK, false).
@@ -65,34 +66,64 @@ make_module_name(Bucket) when is_binary(Bucket) ->
     ModName = "riak_ql_ddl_helper_mod_" ++ Nonce2,
     list_to_atom(ModName).
 
--spec get_partition_key(#ddl_v1{}, tuple()) -> binary().
+-spec get_partition_key(#ddl_v1{}, tuple()) -> term().
 get_partition_key(#ddl_v1{bucket = B, partition_key = PK}, Obj)
   when is_tuple(Obj) ->
     Mod = make_module_name(B),
-    #partition_key_v1{ast = Params} = PK,
-    Key = build(Params, Obj, Mod, []),
-    _K = sext:encode(Key).
+    #key_v1{ast = Params} = PK,
+    _Key = build(Params, Obj, Mod, []).
 
--spec get_local_key(#ddl_v1{}, tuple()) -> binary().
-get_local_key(#ddl_v1{bucket = B, local_key = LK}, Obj) when is_tuple(Obj) ->
-    io:format(user, "Local Key is ~p~n", [LK]),
+-spec get_local_key(#ddl_v1{}, tuple()) -> term().
+get_local_key(#ddl_v1{bucket = B, local_key = LK}, Obj) 
+  when is_tuple(Obj) ->
     Mod = make_module_name(B),
-    #local_key_v1{ast = Params} = LK,
-    Key = build(Params, Obj, Mod, []),
-    _K = sext:encode(Key).
+    #key_v1{ast = Params} = LK,
+    _Key = build(Params, Obj, Mod, []).
 
--spec build([#param_v1{}], tuple(), atom(), any()) -> tuple().
+-spec make_key(atom(), #key_v1{}, list()) -> list(). 
+make_key(Mod, #key_v1{ast = AST}, Vals) when is_atom(Mod)  andalso 
+					     is_list(Vals) ->
+    mk_k(AST, Vals, Mod, []).
+
+%% TODO there is a mismatch between how the fields in the where clause
+%% and the fields in the DDL are mapped
+mk_k([], _Vals, _Mod, Acc) ->
+    lists:reverse(Acc);
+mk_k([#hash_fn_v1{mod = Md,
+		 fn   = Fn,
+		 args = Args,
+		 type = Ty} | T1], Vals, Mod, Acc) ->
+    A2 = extract(Args, Vals, []),
+    V  = erlang:apply(Md, Fn, A2),
+    mk_k(T1, Vals, Mod, [{Ty, V} | Acc]);
+mk_k([#param_v1{name = [Nm]} | T1], Vals, Mod, Acc) ->
+    {Nm, V} = lists:keyfind(Nm, 1, Vals),
+    Ty = Mod:get_field_type([Nm]),
+    mk_k(T1, Vals, Mod, [{Ty, V} | Acc]).
+
+-spec extract(list(), [{any(), any()}], [any()]) -> any().
+extract([], _Vals, Acc) ->
+    lists:reverse(Acc);
+extract([#param_v1{name = [Nm]} | T], Vals, Acc) ->
+    {Nm, Val} = lists:keyfind(Nm, 1, Vals),
+    extract(T, Vals, [Val | Acc]);
+extract([Constant | T], Vals, Acc) ->
+    extract(T, Vals, [Constant | Acc]).
+
+-spec build([#param_v1{}], tuple(), atom(), any()) -> list().
 build([], _Obj, _Mod, A) ->
-    list_to_tuple(lists:reverse(A));
+    lists:reverse(A);
 build([#param_v1{name = Nm} | T], Obj, Mod, A) ->
     Val = Mod:extract(Obj, Nm),
-    build(T, Obj, Mod, [Val | A]);
+    Type = Mod:get_field_type(Nm),
+    build(T, Obj, Mod, [{Type, Val} | A]);
 build([#hash_fn_v1{mod  = Md,
 		   fn   = Fn,
-		   args = Args} | T], Obj, Mod, A) ->
+		   args = Args,
+		   type = Ty} | T], Obj, Mod, A) ->
     A2 = convert(Args, Obj, Mod, []),
-    Res = erlang:apply(Md, Fn, A2),
-    build(T, Obj, Mod, [Res | A]).
+    Val = erlang:apply(Md, Fn, A2),
+    build(T, Obj, Mod, [{Ty, Val} | A]).
 
 -spec convert([#param_v1{}], tuple(), atom(), [any()]) -> any().
 convert([], _Obj, _Mod, Acc) ->
@@ -100,8 +131,8 @@ convert([], _Obj, _Mod, Acc) ->
 convert([#param_v1{name = Nm} | T], Obj, Mod, Acc) ->
     Val = Mod:extract(Obj, Nm),
     convert(T, Obj, Mod, [Val | Acc]);
-convert([Atom | T], Obj, Mod, Acc) ->
-    convert(T, Obj, Mod, [Atom | Acc]).
+convert([Constant | T], Obj, Mod, Acc) ->
+    convert(T, Obj, Mod, [Constant | Acc]).
 
 -spec is_valid_field(#ddl_v1{}, heirarchicalfieldname()) -> boolean().
 is_valid_field(#ddl_v1{bucket = B}, Field) when is_list(Field)->
@@ -172,6 +203,7 @@ extract_f2([{Op, LHS, RHS} | T], Acc) when Op =:= '='    orelse
 	   end,
     extract_f2(T, Acc3).
 
+is_val({word,     _}) -> true;
 is_val({int,      _}) -> true;
 is_val({float,    _}) -> true; 
 is_val({datetime, _}) -> true; 
@@ -181,7 +213,7 @@ is_val(_)             -> false.
 remove_hooky_chars(Nonce) ->
     re:replace(Nonce, "[/|\+|\.|=]", "", [global, {return, list}]).
 
-%-ifdef(TEST).
+-ifdef(TEST).
 -compile(export_all).
 
 -define(VALID,   true).
@@ -193,15 +225,15 @@ remove_hooky_chars(Nonce) ->
 %% Helper Fn for unit tests
 %%
 
-mock_partition_fn(A, B, C) -> {A, B, C}.
+mock_partition_fn(_A, _B, _C) -> mock_result.
 
 make_ddl(Bucket, Fields) when is_binary(Bucket) ->
-    make_ddl(Bucket, Fields, #partition_key_v1{}, #local_key_v1{}).
+    make_ddl(Bucket, Fields, #key_v1{}, #key_v1{}).
 
 make_ddl(Bucket, Fields, PK) when is_binary(Bucket) ->
-    make_ddl(Bucket, Fields, PK, #local_key_v1{}).
+    make_ddl(Bucket, Fields, PK, #key_v1{}).
 
-make_ddl(Bucket, Fields, #partition_key_v1{} = PK, #local_key_v1{} = LK)
+make_ddl(Bucket, Fields, #key_v1{} = PK, #key_v1{} = LK)
   when is_binary(Bucket) ->
     #ddl_v1{bucket        = Bucket,
 	    fields        = Fields,
@@ -214,9 +246,9 @@ make_ddl(Bucket, Fields, #partition_key_v1{} = PK, #local_key_v1{} = LK)
 
 simplest_partition_key_test() ->
     Name = "yando",
-    PK = #partition_key_v1{ast = [
-				  #param_v1{name = [Name]}
-				 ]},
+    PK = #key_v1{ast = [
+			#param_v1{name = [Name]}
+		       ]},
     DDL = make_ddl(<<"simplest_partition_key_test">>,
 		   [
 		    #riak_field_v1{name     = Name,
@@ -227,15 +259,15 @@ simplest_partition_key_test() ->
     {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
     Obj = {<<"yarble">>},
     Result = (catch get_partition_key(DDL, Obj)),
-    ?assertEqual({<<"yarble">>}, sext:decode(Result)).
+    ?assertEqual([{binary, <<"yarble">>}], Result).
 
 simple_partition_key_test() ->
     Name1 = "yando",
     Name2 = "buckle",
-    PK = #partition_key_v1{ast = [
-				  #param_v1{name = [Name1]},
-				  #param_v1{name = [Name2]}
-				 ]},
+    PK = #key_v1{ast = [
+			#param_v1{name = [Name1]},
+			#param_v1{name = [Name2]}
+		       ]},
     DDL = make_ddl(<<"simple_partition_key_test">>,
 		   [
 		    #riak_field_v1{name     = Name2,
@@ -252,22 +284,23 @@ simple_partition_key_test() ->
     {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
     Obj = {<<"one">>, <<"two">>, <<"three">>},
     Result = (catch get_partition_key(DDL, Obj)),
-    ?assertEqual({<<"three">>, <<"one">>}, sext:decode(Result)).
+    ?assertEqual([{binary, <<"three">>}, {binary, <<"one">>}], Result).
 
 function_partition_key_test() ->
     Name1 = "yando",
     Name2 = "buckle",
-    PK = #partition_key_v1{ast = [
-				  #param_v1{name = [Name1]},
-				  #hash_fn_v1{mod  = ?MODULE,
-					      fn   = mock_partition_fn,
-					      args = [
-						      #param_v1{name = [Name2]},
-						      15,
-						      m
-						     ]
-					     }
-				 ]},
+    PK = #key_v1{ast = [
+			#param_v1{name = [Name1]},
+			#hash_fn_v1{mod  = ?MODULE,
+				    fn   = mock_partition_fn,
+				    args = [
+					    #param_v1{name = [Name2]},
+					    15,
+					    m
+					   ],
+				    type = timestamp
+				   }
+		       ]},
     DDL = make_ddl(<<"function_partition_key_test">>,
 		   [
 		    #riak_field_v1{name     = Name2,
@@ -284,44 +317,48 @@ function_partition_key_test() ->
     {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
     Obj = {1234567890, <<"two">>, <<"three">>},
     Result = (catch get_partition_key(DDL, Obj)),
-    Expected = {<<"three">>, {1234567890, 15, m}},
-    ?assertEqual(Expected, sext:decode(Result)).
+    %% Yes the mock partition function is actually computed
+    %% read the actual code, lol
+    Expected = [{binary, <<"three">>}, {timestamp, mock_result}],
+    ?assertEqual(Expected, Result).
 
 complex_partition_key_test() ->
     Name0 = "yerp",
     Name1 = "yando",
     Name2 = "buckle",
     Name3 = "doodle",
-    PK = #partition_key_v1{ast = [
-				  #param_v1{name = [Name0, Name1]},
-				  #hash_fn_v1{mod  = ?MODULE,
-					      fn   = mock_partition_fn,
-					      args = [
-						      #param_v1{name = [
-									Name0,
-									Name2,
-									Name3
-								       ]},
-						      "something",
-						      pong
-						     ]
-					     },
-				  #hash_fn_v1{mod  = ?MODULE,
-					      fn   = mock_partition_fn,
-					      args = [
-						      #param_v1{name = [
-									Name0,
-									Name1
-								       ]},
-						      #param_v1{name = [
-									Name0,
-									Name2,
-									Name3
-								       ]},
-						      pang
-						     ]
-					     }
-				 ]},
+    PK = #key_v1{ast = [
+			#param_v1{name = [Name0, Name1]},
+			#hash_fn_v1{mod  = ?MODULE,
+				    fn   = mock_partition_fn,
+				    args = [
+					    #param_v1{name = [
+							      Name0,
+							      Name2,
+							      Name3
+							     ]},
+					    "something",
+					    pong
+					   ],
+				    type = poodle
+				   },
+			#hash_fn_v1{mod  = ?MODULE,
+				    fn   = mock_partition_fn,
+				    args = [
+					    #param_v1{name = [
+							      Name0,
+							      Name1
+							     ]},
+					    #param_v1{name = [
+							      Name0,
+							      Name2,
+							      Name3
+							     ]},
+					    pang
+					   ],
+				    type = wombat
+				   }
+		       ]},
     Map3 = {map, [
 		  #riak_field_v1{name     = "in_Map_2",
 				 position = 1,
@@ -353,8 +390,8 @@ complex_partition_key_test() ->
     {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
     Obj = {{2, {3}, {4}}},
     Result = (catch get_partition_key(DDL, Obj)),
-    Expected = {2, {3, "something", pong}, {2, 3, pang}},
-    ?assertEqual(Expected, sext:decode(Result)).
+    Expected = [{integer, 2}, {poodle, mock_result}, {wombat, mock_result}],
+    ?assertEqual(Expected, Result).
 
 %%
 %% get local_key tests
@@ -362,12 +399,12 @@ complex_partition_key_test() ->
 
 simplest_local_key_test() ->
     Name = "yando",
-    PK = #partition_key_v1{ast = [
-				  #param_v1{name = [Name]}
-				 ]},
-    LK = #local_key_v1{ast = [
-			      #param_v1{name = [Name]}
-			     ]},
+    PK = #key_v1{ast = [
+			#param_v1{name = [Name]}
+		       ]},
+    LK = #key_v1{ast = [
+			#param_v1{name = [Name]}
+		       ]},
     DDL = make_ddl(<<"simplest_key_key_test">>,
 		   [
 		    #riak_field_v1{name     = Name,
@@ -378,7 +415,7 @@ simplest_local_key_test() ->
     {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
     Obj = {<<"yarble">>},
     Result = (catch get_local_key(DDL, Obj)),
-    ?assertEqual({<<"yarble">>}, sext:decode(Result)).
+    ?assertEqual([{binary, <<"yarble">>}], Result).
 
 %%
 %% get type of named field
@@ -485,6 +522,71 @@ complex_valid_map_get_type_test() ->
     Path = ["Top_Map", "Level_1_map1", "in_Map_1"],
     Res = (catch Module:get_field_type(Path)),
     ?assertEqual(integer, Res).
+
+%%
+%% make_key tests
+%%
+
+make_plain_key_test() ->
+    Key = #key_v1{ast = [
+			 #param_v1{name = ["user"]},
+			 #param_v1{name = ["time"]}
+			]},
+    DDL = make_ddl(<<"make_plain_key_test">>,
+		   [
+		    #riak_field_v1{name     = "user",
+				   position = 1,
+				   type     = binary},
+		    #riak_field_v1{name     = "time",
+				   position = 2,
+				   type     = timestamp}
+		   ],
+		   Key, %% use the same key for both
+		   Key),
+    Time = 12345,
+    Vals = [
+	    {"user", "user_1"},
+	    {"time", Time}
+	   ],
+    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    Got = make_key(Mod, Key, Vals),
+    Expected = [{binary, "user_1"}, {timestamp, Time}],
+    ?assertEqual(Expected, Got).    
+
+make_functional_key_test() ->
+    Key = #key_v1{ast = [
+			 #param_v1{name = ["user"]},
+			 #hash_fn_v1{mod  = ?MODULE,
+				     fn   = mock_partition_fn,
+				     args = [
+					     #param_v1{name = ["time"]},
+					     15,
+					     m
+					    ],
+				     type = timestamp
+				    }
+			]},
+    DDL = make_ddl(<<"make_plain_key_test">>,
+		   [
+		    #riak_field_v1{name     = "user",
+				   position = 1,
+				   type     = binary},
+		    #riak_field_v1{name     = "time",
+				   position = 2,
+				   type     = timestamp}
+		   ],
+		   Key, %% use the same key for both
+		   Key),
+    Time = 12345,
+    Vals = [
+	    {"user", "user_1"},
+	    {"time", Time}
+	   ],
+    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    Got = make_key(Mod, Key, Vals),
+    Expected = [{binary, "user_1"}, {timestamp, mock_result}],
+    ?assertEqual(Expected, Got).    
+
 
 %%
 %% Validate Query Tests
@@ -654,6 +756,37 @@ simple_filter_query_test() ->
     Res = riak_ql_ddl:is_query_valid(DDL, Query),
     ?assertEqual(true, Res).
 
+timeseries_filter_test() ->
+    Bucket = <<"timeseries_filter_test">>,
+    Selections = [["weather"]],
+    Where = [
+	     {and_,
+	      {and_, 
+	       {'>', "time", {int, 3000}},
+	       {'<', "time", {int, 5000}}
+	      },
+	      {'=', "user", {word, "user_1"}
+	       }
+	      }
+	    ],
+    Query = #riak_sql_v1{'FROM'   = Bucket,
+			 'SELECT' = Selections,
+			 'WHERE'  = Where},
+    DDL = {ddl_v1,<<"timeseries_filter_test">>,
+	   [{riak_field_v1,"geohash",1,binary,false},
+	    {riak_field_v1,"user",2,binary,false},
+	    {riak_field_v1,"time",3,timestamp,false},
+	    {riak_field_v1,"weather",4,binary,false},
+	    {riak_field_v1,"temperature",5,binary,true}],
+	   {key_v1,[{hash_fn_v1,riak_ql_quanta,quantum,
+		     [{param_v1,["time"]},15,s]}]},
+	   {key_v1,[{param_v1,["time"]},{param_v1,["user"]}]}},
+    {module, _ModName} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    Res = riak_ql_ddl:is_query_valid(DDL, Query),
+    Expected = true,
+    ?assertEqual(Expected, Res).
+		    
+
 simple_filter_query_fail_test() ->
     Bucket = <<"simple_filter_query_fail_test">>,
     Selections = [["temperature"], ["geohash"]],
@@ -684,4 +817,4 @@ simple_filter_query_fail_test() ->
 	       },
     ?assertEqual(Expected, Res).
 
-%-endif.
+-endif.

--- a/src/riak_ql_ddl_compiler.erl
+++ b/src/riak_ql_ddl_compiler.erl
@@ -69,7 +69,7 @@
 -type map()    :: {map,  [#riak_field_v1{}]}.
 
 
--spec make_helper_mod(#ddl_v1{}) -> {module, atom()} | {'error', tuple()}.
+-spec make_helper_mod(#ddl_v1{}) -> {module, atom()} | {'error', any()}.
 make_helper_mod(#ddl_v1{} = DDL) ->
     make_helper_mod(DDL, "/tmp", ?NODEBUGOUTPUT).
 
@@ -96,7 +96,7 @@ mk_helper_m2(#ddl_v1{} = DDL, OutputDir) ->
     mk_helper_m2(DDL, OutputDir, ?DEBUGOUTPUT).
 
 -spec mk_helper_m2(#ddl_v1{}, string(), boolean()) ->
-                             {module, atom()} | {'error', tuple()}.
+			  {module, atom()} | {'error', tuple()}.
 mk_helper_m2(#ddl_v1{} = DDL, OutputDir, HasDebugOutput) ->
     case validate_ddl(DDL) of
         true ->
@@ -232,15 +232,17 @@ compile(#ddl_v1{} = DDL, OutputDir, HasDebugOutput) ->
 write_src(AST, DDL, SrcFileName) ->
     AST2 = filter_ast(AST, []),
     Syntax = erl_syntax:form_list(AST2),
-    Header = io_lib:format("%%% Generated Module, do NOT edit~n~n" ++
+    Header = io_lib:format("%%% Generated Module, DO NOT EDIT~n~n" ++
                                "Validates the DDL~n~n" ++
                                "Bucket        : ~s~n" ++
                                "Fields        : ~p~n" ++
-                               "Partition_Key : ~p~n~n",
+                               "Partition_Key : ~p~n" ++
+			       "Local_Key     : ~p~n~n",
                            [
                             binary_to_list(DDL#ddl_v1.bucket),
                             DDL#ddl_v1.fields,
-                            DDL#ddl_v1.partition_key
+                            DDL#ddl_v1.partition_key,
+			    DDL#ddl_v1.local_key
                            ]),
     Header2 = re:replace(Header, "\\n", "\\\n%%% ", [global, {return, list}]),
     Src = erl_prettypr:format(Syntax),
@@ -297,7 +299,7 @@ make_extract_cls([#riak_field_v1{type = Ty} = H | T], LineNo, Prefix, Acc) ->
     make_extract_cls(T, NewLineNo, Prefix, NewA).
 
 -spec build_is_valid_fn([[#riak_field_v1{}]], pos_integer(), ast()) ->
-                              {expr(), pos_integer()}.
+			       {expr(), pos_integer()}.
 build_is_valid_fn([], LineNo, Acc) ->
     {Fail, NewLineNo} = make_fail_clause(LineNo),
     Clauses = lists:flatten(lists:reverse([Fail | Acc])),
@@ -337,7 +339,7 @@ make_is_valid_cls([#riak_field_v1{type = Ty} = H | T], LineNo, Prefix, Acc) ->
     make_is_valid_cls(T, NewLineNo, Prefix, NewA).
 
 -spec build_get_type_fn([[#riak_field_v1{}]], pos_integer(), ast()) ->
-                              {expr(), pos_integer()}.
+			       {expr(), pos_integer()}.
 build_get_type_fn([], LineNo, Acc) ->
     Clauses = lists:flatten(lists:reverse(Acc)),
     Fn = make_fun(get_field_type, 1, Clauses, LineNo),
@@ -355,9 +357,9 @@ make_get_type_cls([#riak_field_v1{type = Ty} = H | T], LineNo, Prefix, Acc) ->
     %% you need to reverse the lists of the positions to
     %% get the calls to element to nest correctly
     Body = case Ty of
-                {map, _}  -> make_atom(map, LineNo);
-                _         -> make_atom(Ty, LineNo)
-            end,
+	       {map, _}  -> make_atom(map, LineNo);
+	       _         -> make_atom(Ty, LineNo)
+	   end,
     Guard = [],
     Cl = make_clause([Conses], Guard, Body, LineNo),
     {NewA, NewLineNo} =
@@ -603,12 +605,12 @@ make_ddl(#ddl_v1{bucket = Bucket,
     make_ddl(Bucket, Fields, PK, LK).
 
 make_ddl(Bucket, Fields) when is_binary(Bucket) ->
-    make_ddl(Bucket, Fields, #partition_key_v1{}, #local_key_v1{}).
+    make_ddl(Bucket, Fields, #key_v1{}, #key_v1{}).
 
 make_ddl(Bucket, Fields, PK) when is_binary(Bucket) ->
-    make_ddl(Bucket, Fields, PK, #local_key_v1{}).
+    make_ddl(Bucket, Fields, PK, #key_v1{}).
 
-make_ddl(Bucket, Fields, #partition_key_v1{} = PK, #local_key_v1{} = LK)
+make_ddl(Bucket, Fields, #key_v1{} = PK, #key_v1{} = LK)
   when is_binary(Bucket) ->
     #ddl_v1{bucket        = Bucket,
             fields        = Fields,
@@ -1277,10 +1279,10 @@ complex_invalid_map_1_test() ->
                    ]),
     {module, Module} = mk_helper_m2(DDL),
     Result = Module:validate_obj({<<"ewrewr">>,
-                              {<<"erko">>,
-                               {<<"yerk">>, 33.0}
-                              },
-                              4.4}),
+				  {<<"erko">>,
+				   {<<"yerk">>, 33.0}
+				  },
+				  4.4}),
     ?assertEqual(?INVALID, Result).
 
 %%% test the size of the tuples
@@ -1500,25 +1502,16 @@ complex_ddl_test() ->
                           name = "user_id",
                           position = 2,
                           type = binary,
-                          optional = false}],
-             partition_key = #partition_key_v1{
-                                ast = [#param_v1{
-                                          name = "time"
-                                         },
-                                       #hash_fn_v1{
-                                              mod = crypto,
-                                          fn = hash,
-                                          args = [sha512]
-                                         }]},
-             local_key = #local_key_v1{
-                            ast = [#hash_fn_v1{
-                                          mod = crypto,
-                                      fn = hash,
-                                      args = [ripemd]
-                                     },
-                                   #param_v1{
-                                      name = "time"
-                                     }]}},
+                          optional = false}
+		      ],
+             partition_key = #key_v1{ast = [
+					    #param_v1{name = "time"},
+					    #hash_fn_v1{mod = crypto, fn = hash, args = [sha512]}
+					   ]},
+             local_key = #key_v1{ast = [
+					#hash_fn_v1{mod = crypto, fn = hash, args = [ripemd]},
+					#param_v1{name = "time"}
+				       ]}},
     {module, Module} = mk_helper_m2(DDL),
     Result = Module:validate_obj({12345, <<"beeees">>}),
     ?assertEqual(?VALID, Result).

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -84,7 +84,7 @@ Rootsymbol Statement.
 Endsymbol '$end'.
 
 Statement -> Query : convert('$1').
-Statement -> TableDefinition : '$1'.
+Statement -> TableDefinition : fix_up_keys('$1').
 
 Query -> Select limit int : add_limit('$1', '$2', '$3').
 Query -> Select           : '$1'.
@@ -112,9 +112,10 @@ Word -> chars      : process('$1').
 Funcall -> Word openb     closeb : make_funcall('$1').
 Funcall -> Word openb Val closeb : make_funcall('$1').
 
-Conds -> openb Conds closeb  : make_expr('$2').
-Conds -> Conds Logic Cond    : make_expr('$1', '$2', '$3').
-Conds -> Cond                : '$1'.
+Conds -> openb Conds closeb             : make_expr('$2').
+Conds -> Conds Logic Cond               : make_expr('$1', '$2', '$3').
+Conds -> Conds Logic openb Conds closeb : make_expr('$1', '$2', '$4').
+Conds -> Cond                           : '$1'.
 
 Cond -> Vals Comp Vals : make_expr('$1', '$2', '$3').
 
@@ -132,6 +133,7 @@ Val -> int       : '$1'.
 Val -> float     : '$1'.
 Val -> datetime  : '$1'.
 Val -> varchar   : '$1'.
+Val -> quoted    : make_word('$1').
 
 Logic -> and_ : '$1'.
 Logic -> or_  : '$1'.
@@ -175,7 +177,7 @@ DataType -> varchar : '$1'.
 KeyDefinition ->
     primary_key       openb KeyFieldList closeb                           : make_local_key('$3').
 KeyDefinition ->
-    primary_key openb openb KeyFieldList closeb comma KeyFieldList closeb : make_partition_keys('$4', '$7').
+    primary_key openb openb KeyFieldList closeb comma KeyFieldList closeb : make_partition_and_local_keys('$4', '$7').
 
 KeyFieldList -> KeyField comma KeyFieldList : make_list('$3', '$1').
 KeyFieldList -> KeyField : make_list({list, []}, '$1').
@@ -188,9 +190,9 @@ KeyFieldArgList ->
 KeyFieldArgList ->
     KeyFieldArg : make_list({list, []}, '$1').
 
-KeyFieldArg -> int   : '$1'.
-KeyFieldArg -> float : '$1'.
-KeyFieldArg -> Word  : '$1'.
+KeyFieldArg -> int    : '$1'.
+KeyFieldArg -> float  : '$1'.
+KeyFieldArg -> Word   : '$1'.
 KeyFieldArg -> atom openb Word closeb : make_atom('$3').
 
 Erlang code.
@@ -220,15 +222,30 @@ Erlang code.
 -include("riak_ql.yrl.tests").
 -endif.
 
+%% if no partition key is specified hash on the local key
+fix_up_keys(#ddl_v1{partition_key = none, local_key = LK} = DDL) ->
+    DDL#ddl_v1{partition_key = LK, local_key = LK};
+fix_up_keys(A) ->
+    A.
+
 convert(#outputs{type    = select,
 		 buckets = B,
 		 fields  = F,
 		 limit   = L,
 		 where   = W}) ->
-    Q = #riak_sql_v1{'SELECT' = F,
-		     'FROM'   = B,
-		     'WHERE'  = W,
-		     'LIMIT'  = L},
+    Q = case B of
+	    {Type, _} when Type =:= list orelse Type =:= regex ->
+		#riak_sql_v1{'SELECT' = F,
+			     'FROM'   = B,
+			     'WHERE'  = W,
+			     'LIMIT'  = L};
+	    _ ->
+		#riak_sql_v1{'SELECT'   = F,
+			     'FROM'     = B,
+			     'WHERE'    = W,
+			     'LIMIT'    = L,
+			     helper_mod = riak_ql_ddl:make_module_name(B)}
+	end,
     Q;
 convert(#outputs{type = create} = O) ->
     O.
@@ -287,9 +304,91 @@ make_expr({_, A}, {B, _}, {Type, C}) ->
          end,
     {conditional, {B1, A, C2}}.
 
-make_where({where, A}, {conditional, B}) ->
-    {A, [remove_conditionals(B)]}.
+make_word({quoted, Q}) -> {word, Q}.
 
+make_where({where, A}, {conditional, B}) ->
+    NewB = remove_conditionals(B),
+    {A, [canonicalise(NewB)]}.
+
+%%
+%% rewrite the where clause to have a canonical form
+%% makes query rewriting easier
+%%
+canonicalise(WhereClause) ->
+    Canonical = canon2(WhereClause),
+    _NewWhere = hoist(Canonical).
+
+canon2({Cond, A, B}) when Cond =:= and_ orelse
+			  Cond =:= or_  ->
+    %% this is stack busting non-tail recursion
+    %% but our where clauses are bounded in size so thats OK
+    A1 = canon2(A),
+    B1 = canon2(B),
+    case is_lower(A1, B1) of
+	true  -> {Cond, A1, B1};
+	false -> {Cond, B1, A1}
+    end;
+canon2(A) ->
+    A.
+
+hoist({and_, {and_, A, B}, C}) ->
+    Hoisted = {and_, A, hoist({and_, B, C})},
+    _Sort = sort(Hoisted);
+hoist({A, B, C}) ->
+    B2 = case B of
+	     {and_, _, _} -> hoist(B);
+	     _            -> B
+	 end,
+    C2 = case C of
+	     {and_, _, _} -> hoist(C);
+	     _            -> C
+	 end,
+    {A, B2, C2}.
+
+%% a truly horendous bubble sort algo which is also
+%% not tail recursive
+sort({and_, A, {and_, B, C}}) ->
+    case is_lower(A, B) of
+	true  -> {and_, B1, C1} = sort({and_, B, C}),
+		 case is_lower(A, B1) of
+		     true  -> {and_, A, {and_, B1, C1}};
+		     false -> sort({and_, B1, {and_, A, C1}})
+		 end;
+	false -> sort({and_, B, sort({and_, A, C})})
+    end;
+sort({Op, A, B}) ->
+    case is_lower(A, B) of
+	true  -> {Op, A, B};
+	false -> {Op, B, A}
+    end.
+
+is_lower(Ands, {_, _, _}) when is_list(Ands)->
+    true;
+is_lower({_, _, _}, Ands) when is_list(Ands)->
+    true;
+is_lower(Ands1, Ands2) when is_list(Ands1) andalso is_list(Ands2) ->
+    true;
+is_lower({Op1, _, _} = A, {Op2, _, _} = B) when (Op1 =:= and_ orelse
+					 Op1 =:= or_  orelse
+					 Op1 =:= '>'  orelse
+					 Op1 =:= '<'  orelse
+					 Op1 =:= '='  orelse
+					 Op1 =:= '<>' orelse
+					 Op1 =:= '=~' orelse
+					 Op1 =:= '!~' orelse
+					 Op1 =:= '!=') 
+					andalso
+					(Op2 =:= and_ orelse
+					 Op2 =:= or_  orelse
+					 Op2 =:= '>'  orelse
+					 Op2 =:= '<'  orelse
+					 Op2 =:= '='  orelse
+					 Op2 =:= '<>' orelse
+					 Op2 =:= '=~' orelse
+					 Op2 =:= '!~' orelse
+					 Op2 =:= '!=') ->
+    (A < B).
+				     
 remove_conditionals({conditional, A}) ->
     A;
 remove_conditionals({A, B, C}) ->
@@ -330,16 +429,21 @@ make_column({word, FieldName}, {DataType, _}, {not_null, _}) ->
        type = canonicalize_field_type(DataType),
        optional = false}.
 
+%% if only the local key is defined
+%% use it as the partition key as well
 make_local_key(FieldList) ->
-    #local_key_v1{
-       ast = lists:reverse(extract_key_field_list(FieldList, []))}.
-
-make_partition_keys(PFieldList, LFieldList) ->    
+    Key = #key_v1{ast = lists:reverse(extract_key_field_list(FieldList, []))},
     [
-     #partition_key_v1{
-	ast = lists:reverse(extract_key_field_list(PFieldList, []))},
-     #local_key_v1{
-	ast = lists:reverse(extract_key_field_list(LFieldList, []))}
+     {partition_key, Key},
+     {local_key,     Key}
+    ].
+
+make_partition_and_local_keys(PFieldList, LFieldList) ->    
+    PFields = lists:reverse(extract_key_field_list(PFieldList, [])),
+    LFields = lists:reverse(extract_key_field_list(LFieldList, [])),
+    [
+     {partition_key, #key_v1{ast = PFields}},
+     {local_key,     #key_v1{ast = LFields}}
     ].
     
 make_table_element_list(A, {table_element_list, B}) ->
@@ -367,30 +471,32 @@ make_table_definition({word, BucketName}, Contents) ->
        local_key = LocalKey,
        fields = Fields}.
 
-find_partition_key({table_element_list, Elements}) ->
-    find_partition_key(Elements);
 find_partition_key([]) ->
     none;
-find_partition_key([PartitionKey = #partition_key_v1{} | _Rest]) ->
-    PartitionKey;
+find_partition_key({table_element_list, Elements}) ->
+    find_partition_key(Elements);
+find_partition_key([{partition_key, Key} | _Rest]) ->
+    Key;
 find_partition_key([_Head | Rest]) ->
     find_partition_key(Rest).
 
-find_local_key({table_element_list, Elements}) ->
-    find_local_key(Elements);
 find_local_key([]) ->
     none;
-find_local_key([LocalKey = #local_key_v1{} | _Rest]) ->
-    LocalKey;
+find_local_key({table_element_list, Elements}) ->
+    find_local_key(Elements);
+find_local_key([{local_key, Key} | _Rest]) ->
+    Key;
 find_local_key([_Head | Rest]) ->
     find_local_key(Rest).
 
 make_modfun(quantum, {list, Args}) ->
     [Param, Quantity, Unit] = lists:reverse(Args),
     {modfun, #hash_fn_v1{
-       mod  = riak_ql_quanta,
-       fn   = quantum,
-       args = [#param_v1{name = [Param]}, Quantity, list_to_existing_atom(Unit)]}}.
+		mod  = riak_ql_quanta,
+		fn   = quantum,
+		args = [#param_v1{name = [Param]}, Quantity, list_to_existing_atom(Unit)],
+		type = timestamp
+	       }}.
 
 find_fields({table_element_list, Elements}) ->
     find_fields(1, Elements, []).

--- a/tools.mk
+++ b/tools.mk
@@ -6,8 +6,9 @@ REBAR ?= ./rebar
 compile-no-deps:
 	${REBAR} compile skip_deps=true
 
-test: compile
-	${REBAR} eunit skip_deps=true
+#test: compile
+#	${REBAR} eunit skip_deps=true
+## overridden in ../Makefile, with special care to remove ./eunit/* etc.
 
 docs:
 	${REBAR} doc skip_deps=true


### PR DESCRIPTION
* the lexer/parser now canonicalises the where clauses to
  make processing them in the query compiler/rewriter easier
* the #riak_sql{} (which is misnamed and will be changed
  to #riak_sql_select{} in a subsequent change) has been
  extended to carry more information for use as it passes
  through the query pipeline
* the local and partition key definitions are now merged
  to simplify processing in the query pipeline
* when a keyfetch is done against incoming data it now
  returns as a list of typed terms so that the encoder
  knows how to encode it
  - ie it used to return a physical key
       now it returns a logical key