### PR TITLE
fix test target in Makefile to enable rebar eunit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ clean:
 distclean: clean
 	./rebar delete-deps
 
+testclean: clean
+	@rm -rf eunit.log .eunit/*
+
+test: testclean compile
+	./rebar eunit skip_deps=true
+
 DIALYZER_APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
 	xmerl webtool snmp public_key mnesia eunit syntax_tools compiler
 

--- a/tools.mk
+++ b/tools.mk
@@ -6,8 +6,9 @@ REBAR ?= ./rebar
 compile-no-deps:
 	${REBAR} compile skip_deps=true
 
-test: compile
-	${REBAR} eunit skip_deps=true
+#test: compile
+#	${REBAR} eunit skip_deps=true
+## overridden in ../Makefile, with special care to remove ./eunit/* etc.
 
 docs:
 	${REBAR} doc skip_deps=true


### PR DESCRIPTION
A trivial Makefile tweak to enable rebar eunit.