### PR TITLE
Select case sensitive RTS-264

### DIFF
--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -6,6 +6,14 @@
 	Got = parse(Toks),
 	?assertEqual({ok, Expected}, Got)).
 
+% assert match is useful for only matching part of the output, that
+% is being tested and not the whole state to prevent tests failing
+% on irrelevant changes.
+-define(sql_compilation_assert_match(String, Expected),
+	Toks = riak_ql_lexer:get_tokens(String),
+	Got = parse(Toks),
+	?assertMatch({ok, Expected}, Got)).
+
 -define(sql_compilation_fail(QL_string),
 	Toks = riak_ql_lexer:get_tokens(QL_string),
 	Got = parse(Toks),
@@ -416,6 +424,14 @@ create_timeseries_sql_test() ->
 				       ]}
 		 },
     ?assertEqual(Expected, Got).
+
+select_sql_case_insensitive_1_test() ->
+    ?sql_compilation_assert_match("SELECT * from argle",
+				  #riak_sql_v1{'SELECT' = [["*"]]}).
+
+select_sql_case_insensitive_2_test() ->
+    ?sql_compilation_assert_match("seLEct * from argle",
+				  #riak_sql_v1{'SELECT' = [["*"]]}).
 
 %%%
 %%% Failure tests

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -199,7 +199,7 @@ Erlang code.
 
 -record(outputs,
         {
-          type    = [] :: select | create,
+          type :: select | create,
           buckets = [],
           fields  = [],
           limit   = [],
@@ -258,7 +258,7 @@ make_clause({select, A}, {_, B}, {from, _C}, {Type, D}, {_, E}) ->
 		 list   -> {Type2, [list_to_binary(X) || X <- D]};
 		 regex  -> {Type2, D}
 	     end,
-    _O = #outputs{type    = list_to_existing_atom(A),
+    _O = #outputs{type    = list_to_existing_atom(string:to_lower(A)),
                   fields  = [[X] || X <- B],
                   buckets = Bucket,
                   where   = E


### PR DESCRIPTION
The tokens for the SELECT keyword were directly converted to an existing atom which meant that the record #outputs.type may have been set to the atom 'SELECT', this would lead to badmatch crashes later on in the code. Fix is to just make it lower case.