### PR TITLE
Export riak_ql_ddl_compiler:compile/1

### DIFF
--- a/src/riak_ql_ddl_compiler.erl
+++ b/src/riak_ql_ddl_compiler.erl
@@ -36,6 +36,7 @@
 -include("riak_ql_ddl.hrl").
 
 -export([
+         compile/1,
          make_helper_mod/1,
          make_helper_mod/2
         ]).
@@ -191,6 +192,12 @@ validate_fields([H | T], Acc) ->
 %%
 %% funs to compile the DDL to its helper module AST
 %%
+
+-spec compile(#ddl_v1{}) ->
+                     {module, ast()} | {'error', tuple()}.
+compile(DDL) ->
+    Debug = false,
+    compile(DDL, << >>, Debug).
 
 -spec compile(#ddl_v1{}, binary(), boolean()) ->
                      {module, ast()} | {'error', tuple()}.


### PR DESCRIPTION
Export riak_ql_ddl_compiler:compile/1 which is compile/3 but without the debug options. This is used in the DDL distributon code in riak_kv to compile DDLs to AST.