### PR TITLE
riak_ql linter command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/riak_ql_parser.erl
 _build
 rebar.lock
 .local_dialyzer_plt
+riak_ql

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %% -*- erlang -*-
 {cover_enabled, true}.
 {erl_opts, [
-	    debug_info, 
+	    debug_info,
 	    warnings_as_errors,
 	    {i, "deps/riak_kv/include"}
 	   ]}.
@@ -18,6 +18,10 @@ verbose
 %     {report, {eunit_progress, [colored, profile]}} %% Use `profile' to see test timing information
      %% Uses the progress formatter with ANSI-colored output
      ]}.
+
+%% == escriptize ==
+{escript_emu_args, "%%! -escript main riak_ql_cmd -smp disable +A 0\n"}.
+{escript_incl_apps, [sext]}.
 
 {deps, [
         {sext, ".*", {git, "git://github.com/basho/sext.git", {tag, "1.1p3"}}}

--- a/src/riak_ql_cmd.erl
+++ b/src/riak_ql_cmd.erl
@@ -1,0 +1,65 @@
+%% -------------------------------------------------------------------
+%%
+%% An escript command for linting riak_ql queries. Create the
+%% riak_ql command by running:
+%%
+%%    ./rebar escriptize
+%%
+%% There should now be a runnable riak_ql file in the project
+%% directory. Usage:
+%%
+%%     ./riak_ql "SELECT * FROM my_table"
+%%     ./riak_ql "CREATE TABLE my_table(my_field int, PRIMARY KEY(my_field))"
+%%
+%% This lints the last given argument, a syntax error is printed
+%% if one exists, otherwise there is no output. To print out the
+%% generated ddl add -ddl before the last command:
+%%
+%%     ./riak_ql -ddl "SELECT * FROM my_table"
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_ql_cmd).
+
+-export([main/1]).
+
+-include("riak_ql_ddl.hrl").
+
+%%
+main([_|_] = Args) ->
+    Query = lists:last(Args),
+    Lexed = riak_ql_lexer:get_tokens(Query),
+    case riak_ql_parser:parse(Lexed) of
+        {ok, DDL} ->
+            maybe_print_ddl(Args, DDL);
+        {error, {Token,_,_}} ->
+            io:format("Error: syntax error before ~s~n", [Token]),
+            % return an error code for the proc if an error has occurred
+            erlang:halt(1)
+    end;
+main([]) ->
+    io:format(
+        "Invalid usage, try: ./riak_ql \"SELECT * FROM my_table\"~n").
+
+%%
+maybe_print_ddl(Args, DDL) ->
+    case lists:member("-ddl", Args) of
+        true  -> io:format("~p~n", [DDL]);
+        false -> ok
+    end.


### PR DESCRIPTION
An escript command for linting riak_ql queries. Create the riak_ql command by running:

   ./rebar escriptize

There should now be a runnable riak_ql file in the project directory. Usage:

```
./riak_ql "SELECT * FROM my_table"
./riak_ql "CREATE TABLE my_table(my_field int, PRIMARY KEY(my_field))"
```

This lints the last given argument, a syntax error is printed if one exists, otherwise there is no output. To print out the generated ddl add -ddl before the last command:

```
./riak_ql -ddl "SELECT * FROM my_table"
```
