### PR TITLE
SQL has a laxer view of scientific notation than Erlang's list_to_float/1 fn

### DIFF
--- a/src/riak_ql.xrl.tests
+++ b/src/riak_ql.xrl.tests
@@ -136,14 +136,20 @@ words_containing_digits_test_() ->
     ?_assertEqual(Expected, Got).
 
 nums_test_() ->
-    Got = riak_ql_lexer:get_tokens("1 -2 2.0 -2.0 3.3e+3 -3.3e-3"),
+    Got = riak_ql_lexer:get_tokens("1 -2 2.0 -2.0 3.3e+3 -3.3e-3 44e4 44e-4 44e+4 44e-0 44e+0 44e0"),
     Expected = [
                 {integer, 1},
                 {integer, -2},
                 {float, 2.0},
                 {float, -2.0},
-                {float, 3300.0},
-                {float, -0.0033}
+                {float, 3.3e3},
+                {float, -0.0033},
+                {float, 4.4e5},
+                {float, 0.0044},
+                {float, 4.4e5},
+                {float, 44.0},
+                {float, 44.0},
+                {float, 44.0}
                ],
     ?_assertEqual(Expected, Got).
 

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -112,7 +112,7 @@ Rules.
 
 {INTNUM}   : {token, {integer, list_to_integer(TokenChars)}}.
 {FLOATDEC} : {token, {float, list_to_float(TokenChars)}}.
-{FLOATSCI} : {token, {float, list_to_float(TokenChars)}}.
+{FLOATSCI} : {token, {float, sci_to_float(TokenChars)}}.
 
 {EQ}          : {token, {eq,     list_to_binary(TokenChars)}}.
 {APPROXMATCH} : {token, {approx, list_to_binary(TokenChars)}}.
@@ -261,7 +261,26 @@ fix_up_date(Date) ->
         ParsedDate        -> {datetime, ParsedDate}
     end.
 
-
 strip_quoted(QuotedString) ->
     StrippedOutsideQuotes = string:strip(QuotedString, both, $"),
     re:replace(StrippedOutsideQuotes, "\"\"", "\"", [global, {return, binary}]).
+
+sci_to_float(Chars) ->
+    [Mantissa, Exponent] = re:split(Chars, "E|e", [{return, list}]),
+    M2 = normalise_mant(Mantissa),
+    E2 = normalise_exp(Exponent),
+    sci_to_f2(M2, E2).
+
+sci_to_f2(M2, E) when E =:= "+0" orelse
+                      E =:= "-0" -> list_to_float(M2);
+sci_to_f2(M2, E2) -> list_to_float(M2 ++ "e" ++ E2).
+
+normalise_mant(Mantissa) ->
+    case length(re:split(Mantissa, "\\.", [{return, list}])) of
+        1 -> Mantissa ++ ".0";
+        2 -> Mantissa
+    end.
+
+normalise_exp("+" ++ No) -> "+" ++ No;
+normalise_exp("-" ++ No) -> "-" ++ No;
+normalise_exp(No)        -> "+" ++ No.


### PR DESCRIPTION
So some yucky jiggery-pokery is in order
