### PR TITLE
Error when unicode is used in an identifier RTS-593

### DIFF
--- a/src/riak_ql.xrl.tests
+++ b/src/riak_ql.xrl.tests
@@ -184,8 +184,15 @@ unicode_character_literal_test_() ->
 unicode_identifier_test_() ->
     ?_assertException(
         error,
-        unicode_not_supported,
+        unicode_in_identifier,
         riak_ql_lexer:get_tokens("πίτσα пицца ピザ 比萨")
+    ).
+
+unicode_quoted_test_() ->
+    ?_assertException(
+        error,
+        unicode_in_quotes,
+        riak_ql_lexer:get_tokens("\"helピザlo\"")
     ).
 
 inner_zero_test_() ->

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -152,7 +152,7 @@ Rules.
 \n : {end_token, {'$end'}}.
 
 {IDENTIFIER} : {token, {identifier, list_to_binary(TokenChars)}}.
-{UNICODE} : error(unicode_not_supported).
+{UNICODE} : error(unicode_in_identifier).
 
 .  : {token, {identifier, list_to_binary(TokenChars)}}.
 
@@ -196,6 +196,9 @@ fix_up_date(Date) ->
     end.
 
 strip_quoted(QuotedString) ->
+    % if there are unicode characters in the string, throw an error
+    [error(unicode_in_quotes) || U <- QuotedString, U > 127],
+
     StrippedOutsideQuotes = string:strip(QuotedString, both, $"),
     re:replace(StrippedOutsideQuotes, "\"\"", "\"", [global, {return, binary}]).
 


### PR DESCRIPTION
The exception `unicode_not_supported` is now raised when unicode is used as an identifier, for example a column or table name.  Unicode can still be used inside a char literal, for example:

```
mycol = 'Здравствуйте'
```

Returning the offending unicode in the exception is avoided because of the problems printing it correctly in erlang.
