### PR TITLE
Remove white space from tokens RTS-612

### DIFF
--- a/src/riak_ql.xrl.tests
+++ b/src/riak_ql.xrl.tests
@@ -106,7 +106,8 @@ keywords_create_test_() ->
                 {table, <<"table">>},
                 {not_, <<"not">>},
                 {null, <<"null">>},
-                {primary_key, <<"primary key">>}],
+                {primary, <<"primary">>},
+                {key, <<"key">>}],
     ?_assertEqual(Expected, Got).
 
 words_containing_keywords_test_() ->
@@ -392,7 +393,8 @@ timeseries_test_() ->
                 {double, <<"double">>},
                 {identifier,<<"not_null">>},
                 {comma, <<",">>},
-                {primary_key, <<"PRIMARY KEY">>},
+                {primary, <<"PRIMARY">>},
+                {key, <<"KEY">>},
                 {openb, <<"(">>},
                 {openb, <<"(">>},
                 {identifier,<<"geohash">>},

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -6,9 +6,9 @@
 Definitions.
 
 AND = (A|a)(N|n)(D|d)
+ANY  = (A|a)(N|n)(Y|y)
 AS = (A|a)(S|s)
 ATOM = (A|a)(T|t)(O|o)(M|m)
-ANY  = (A|a)(N|n)(Y|y)
 BOOLEAN = (B|b)(O|o)(O|o)(L|l)(E|e)(A|a)(N|n)
 CREATE = (C|c)(R|r)(E|e)(A|a)(T|t)(E|e)
 DELETE = (D|d)(E|e)(L|l)(E|e)(T|t)(E|e)
@@ -20,6 +20,7 @@ GLOBAL = (G|g)(L|l)(O|o)(B|b)(A|a)(L|l)
 GROUPBY = (G|g)(R|r)(O|o)(U|u)(P|p)(B|b)(Y|y)
 INNER = (I|i)(N|n)(N|n)(E|e)(R|r)
 JOIN = (J|j)(O|o)(I|i)(N|n)
+KEY = (K|k)(E|e)(Y|y)
 LIMIT = (L|l)(I|i)(M|m)(I|i)(T|t)
 LOCAL = (L|l)(O|o)(C|c)(A|a)(L|l)
 LOCAL_KEY = (L|l)(O|o)(C|c)(A|a)(L|l)\s(K|k)(E|e)(Y|y)
@@ -30,8 +31,8 @@ NULL = (N|n)(U|u)(L|l)(L|l)
 OF = (O|o)(F|f)
 ON_COMMIT = (O|o)(N|n)\s(C|c)(O|o)(M|m)(M|m)(I|i)(T|t)
 OR = (O|o)(R|r)
-PRIMARY_KEY = (P|p)(R|r)(I|i)(M|m)(A|a)(R|r)(Y|y)\s(K|k)(E|e)(Y|y)
 PRESERVE = (P|p)(R|r)(E|e)(S|s)(E|e)(R|r)(V|v)(E|e)
+PRIMARY = (P|p)(R|r)(I|i)(M|m)(A|a)(R|r)(Y|y)
 QUANTUM = (Q|q)(U|u)(A|a)(N|n)(T|t)(U|u)(M|m)
 ROWS = (R|r)(O|o)(W|w)(S|s)
 SELECT = (S|s)(E|e)(L|l)(E|e)(C|c)(T|t)
@@ -80,12 +81,11 @@ COMMA = (,)
 Rules.
 
 {AND} : {token, {and_, list_to_binary(TokenChars)}}.
-{AS} : {token, {as, list_to_binary(TokenChars)}}.
 {ANY} : {token, {any, list_to_binary(TokenChars)}}.
+{AS} : {token, {as, list_to_binary(TokenChars)}}.
 {ATOM} : {token, {atom, list_to_binary(TokenChars)}}.
 {BOOLEAN} : {token, {boolean, list_to_binary(TokenChars)}}.
 {CREATE} : {token, {create, list_to_binary(TokenChars)}}.
-{TABLE} : {token, {table, list_to_binary(TokenChars)}}.
 {DELETE} : {token, {delete, list_to_binary(TokenChars)}}.
 {DOUBLE} : {token, {double, list_to_binary(TokenChars)}}.
 {DROP} : {token, {drop, list_to_binary(TokenChars)}}.
@@ -95,9 +95,10 @@ Rules.
 {GROUPBY} : {token, {groupby, list_to_binary(TokenChars)}}.
 {INNER} : {token, {inner, list_to_binary(TokenChars)}}.
 {JOIN} : {token, {join, list_to_binary(TokenChars)}}.
+{KEY} : {token, {key, list_to_binary(TokenChars)}}.
 {LIMIT} : {token, {limit, list_to_binary(TokenChars)}}.
-{LOCAL} : {token, {local, list_to_binary(TokenChars)}}.
 {LOCAL_KEY} : {token, {local_key, list_to_binary(TokenChars)}}.
+{LOCAL} : {token, {local, list_to_binary(TokenChars)}}.
 {MERGE} : {token, {merge, list_to_binary(TokenChars)}}.
 {MODFUN} : {token, {modfun, list_to_binary(TokenChars)}}.
 {NOT} : {token, {not_, list_to_binary(TokenChars)}}.
@@ -105,13 +106,14 @@ Rules.
 {OF} : {token, {of_, list_to_binary(TokenChars)}}.
 {ON_COMMIT} : {token, {on_commit, list_to_binary(TokenChars)}}.
 {OR} : {token, {or_, list_to_binary(TokenChars)}}.
-{PRIMARY_KEY} : {token, {primary_key, list_to_binary(TokenChars)}}.
 {PRESERVE} : {token, {preserve, list_to_binary(TokenChars)}}.
+{PRIMARY} : {token, {primary, list_to_binary(TokenChars)}}.
 {QUANTUM} : {token, {quantum, list_to_binary(TokenChars)}}.
 {ROWS} : {token, {rows, list_to_binary(TokenChars)}}.
 {SELECT} : {token, {select, list_to_binary(TokenChars)}}.
 {SINT64} : {token, {sint64, list_to_binary(TokenChars)}}.
 {SYSTEM_VERSIONING} : {token, {system_versioning, list_to_binary(TokenChars)}}.
+{TABLE} : {token, {table, list_to_binary(TokenChars)}}.
 {TEMPORARY} : {token, {temporary, list_to_binary(TokenChars)}}.
 {TIMESTAMP} : {token, {timestamp, list_to_binary(TokenChars)}}.
 {TRUE} : {token, {true, TokenChars}}.

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -37,59 +37,50 @@ KeyFieldArgList
 KeyFieldArg
 NotNull
 CreateTable
+PrimaryKey
 .
 
 Terminals
 
-select
-from
-limit
-where
+or_
 and_
- or_
-%% delete
-%% drop
-%% groupby
-%% merge
-%% inner
-%% join
-%% as
-datetime
-regex
-integer
-float
 boolean
-sint64
+character_literal
+closeb
+comma
+create
+datetime
+div_
 double
 eq
+false
+float
+from
 gt
-lt
 gte
-lte
-%% ne
-nomatch
-%% approx
-%% notapprox
-openb
-closeb
-plus
-minus
-maybetimes
-div_
-comma
 identifier
-character_literal
-create
-table
+integer
+key
+limit
+lt
+lte
+maybetimes
+minus
+nomatch
 not_
 null
-primary_key
-timestamp
-varchar
-%% atom
+openb
+plus
+primary
 quantum
+regex
+select
+sint64
+table
+timestamp
 true
-false
+varchar
+where
 .
 
 Rootsymbol Statement.
@@ -198,10 +189,12 @@ DataType -> timestamp : '$1'.
 DataType -> varchar   : '$1'.
 DataType -> boolean   : '$1'.
 
+PrimaryKey -> primary key : primary_key.
+
 KeyDefinition ->
-    primary_key       openb KeyFieldList closeb                           : make_local_key('$3').
+    PrimaryKey openb KeyFieldList closeb : make_local_key('$3').
 KeyDefinition ->
-    primary_key openb openb KeyFieldList closeb comma KeyFieldList closeb : make_partition_and_local_keys('$4', '$7').
+    PrimaryKey openb openb KeyFieldList closeb comma KeyFieldList closeb : make_partition_and_local_keys('$4', '$7').
 
 KeyFieldList -> KeyField comma KeyFieldList : make_list('$3', '$1').
 KeyFieldList -> KeyField : make_list({list, []}, '$1').

--- a/test/parser_tests.erl
+++ b/test/parser_tests.erl
@@ -31,3 +31,17 @@ create_table_white_space_test() ->
         riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def))
     ).
 
+primary_key_white_space_test() ->
+    Table_def =
+        "CREATE TABLE temperatures ("
+        "time TIMESTAMP NOT NULL, "
+        "family VARCHAR NOT NULL, "
+        "series VARCHAR NOT NULL, "
+        "PRIMARY               \t  KEY "
+        " ((family, series, quantum(time, 15, 's')), family, series, time))",
+    ?assertMatch(
+        {ok, #ddl_v1{}},
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def))
+    ).
+
+


### PR DESCRIPTION
Where white space appears in a token, it should be two tokens and the white space in-between is ignored. This fixes the requirement of only having one space in-between NOT NULL.  Tokens changed:
- NOT NULL
- CREATE TABLE
- PRIMARY KEY

White space tokens, matching WHITESPACE are now skipped and do not need to be filtered in `riak_ql_lexer:post_p`.
