### PR TITLE
test identifier and literal escaping vs. sql spec

### DIFF
--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -359,6 +359,20 @@ select_quoted_where_sql_test() ->
                                                    ]
                                         }).
 
+select_quoted_escape_sql_test() ->
+    ?sql_compilation_assert("select * from \"table with spaces\" where "
+                            "\"co\"\"or\" = 'klingon''name' or "
+                           "\"co\"\"or\" = '\"'",
+                            #riak_sql_v1{'SELECT' = [[<<"*">>]],
+                                         'FROM'   = <<"table with spaces">>,
+                                         'WHERE' = [
+                                                    {or_,
+                                                     {'=', <<"co\"or">>, {binary, <<"\"">>}},
+                                                     {'=', <<"co\"or">>, {binary, <<"klingon'name">>}}
+                                                    }
+                                                    ]
+                                         }).
+
 select_field_to_field_forbidden_test() ->
     ?sql_compilation_fail("select * from table where time = time").
 


### PR DESCRIPTION
JIRA ticket RTS-613

`005C;REVERSE SOLIDUS;Po;0;ON;;;;;N;BACKSLASH;;;;` from http://www.unicode.org/Public/UNIDATA/UnicodeData.txt , the `Po` value is the Unicode General Category "Punctuation, other". While not valid in unquoted identifiers, it doesn't get special treatment in the SQL spec as a delimited identifier's delimited identifier part (ISO/IEC 9075-2:2011(E) 5.2 "<token>" and "<separator>")  or a character string literal's character representation (5.3 "<literal>").

This commit tests that quote escaping is working as specified by SQL.
