### PR TITLE
Primary Key Fields must exist RTS-622

### DIFF
--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -503,7 +503,7 @@ make_partition_and_local_keys(PFieldList, LFieldList) ->
 make_table_element_list(A, {table_element_list, B}) ->
     {table_element_list, [A] ++ lists:flatten(B)};
 make_table_element_list(A, B) ->
-    {table_element_list, [A, B]}.
+    {table_element_list, lists:flatten([A, B])}.
 
 extract_key_field_list({list, []}, Extracted) ->
     Extracted;
@@ -516,15 +516,12 @@ extract_key_field_list({list, [Field | Rest]}, Extracted) ->
      extract_key_field_list({list, Rest}, Extracted)].
 
 make_table_definition({identifier, Table}, Contents) ->
-    PartitionKey = find_partition_key(Contents),
-    LocalKey = find_local_key(Contents),
-    Fields = find_fields(Contents),
     validate_ddl(
       #ddl_v1{
          table = Table,
-         partition_key = PartitionKey,
-         local_key = LocalKey,
-         fields = Fields}).
+         partition_key = find_partition_key(Contents),
+         local_key = find_local_key(Contents),
+         fields = find_fields(Contents)}).
 
 find_partition_key({table_element_list, Elements}) ->
     find_partition_key(Elements);
@@ -575,20 +572,6 @@ validate_ddl(DDL) ->
     ok = assert_partition_key_fields_exist(DDL),
     ok = assert_primary_key_fields_non_null(DDL),
     DDL.
-
-%%
-assert_partition_key_fields_exist(#ddl_v1{ fields = Fields,
-                                           partition_key =
-                                               #key_v1{ ast = PK } }) ->
-    MissingFields =
-        [binary_to_list(N) || #param_v1{name = [N]} <- PK, lists:keyfind(N, 2, Fields) /= false],
-    case MissingFields of
-        [] ->
-            ok;
-        _ ->
-            return_error_flat("Primary key fields do not exist (~s)",
-                              [string:join(MissingFields, ", ")])
-    end.
 
 %% @doc Ensure DDL can haz keys
 assert_keys_present(#ddl_v1{local_key = LK, partition_key = PK})
@@ -654,6 +637,32 @@ assert_unique_fields_in_pk(#ddl_v1{local_key = #key_v1{ast = LK}}) ->
                      [binary_to_list(F) || F <- Fields])),
                  ", ")])
     end.
+
+
+
+%% Ensure that all fields in the primary key exist in the table definition.
+assert_partition_key_fields_exist(#ddl_v1{ fields = Fields,
+                                           partition_key =
+                                               #key_v1{ ast = PK } }) ->
+    MissingFields =
+        [binary_to_list(name_of(F)) || F <- PK, not is_field(F, Fields)],
+    case MissingFields of
+        [] ->
+            ok;
+        _ ->
+            return_error_flat("Primary key fields do not exist (~s).",
+                              [string:join(MissingFields, ", ")])
+    end.
+
+%% Check that the field name exists in the list of fields.
+is_field(Field, Fields) ->
+    (lists:keyfind(name_of(Field), 2, Fields) /= false).
+
+%%
+name_of(#param_v1{ name = [N] }) ->
+    N;
+name_of(#hash_fn_v1{ args = [#param_v1{ name = [N] }|_] }) ->
+    N.
 
 which_duplicate(FF) ->
     which_duplicate(FF, []).

--- a/test/parser_tests.erl
+++ b/test/parser_tests.erl
@@ -115,3 +115,38 @@ function_as_arg_test() ->
         {error, {0, riak_ql_parser, <<"Functions not supported but 'herfun' called as function.">>}},
         riak_ql_parser:parse(riak_ql_lexer:get_tokens("select f from a WHERE myfun(hisfun(herfun(a))) = 'a'"))
     ).
+
+key_fields_must_exist_1_test() ->
+    Table_def =
+        "CREATE TABLE temperatures ("
+        "time TIMESTAMP NOT NULL, "
+        "series VARCHAR NOT NULL, "
+        "PRIMARY KEY "
+        " ((family, series, quantum(time, 15, 's')), family, series, time))",
+    ?assertEqual(
+        {error, {0, riak_ql_parser, <<"Primary key fields do not exist (family).">>}},
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def))
+    ).
+
+key_fields_must_exist_2_test() ->
+    Table_def =
+        "CREATE TABLE temperatures ("
+        "time TIMESTAMP NOT NULL, "
+        "PRIMARY KEY "
+        " ((family, series, quantum(time, 15, 's')), family, series, time))",
+    ?assertEqual(
+        {error, {0, riak_ql_parser, <<"Primary key fields do not exist (family, series).">>}},
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def))
+    ).
+
+key_fields_must_exist_3_test() ->
+    Table_def =
+        "CREATE TABLE temperatures ("
+        "family VARCHAR NOT NULL, "
+        "series VARCHAR NOT NULL, "
+        "PRIMARY KEY "
+        " ((family, series, quantum(time, 15, 's')), family, series, time))",
+    ?assertMatch(
+        {error, {0, riak_ql_parser, <<"Primary key fields do not exist (time).">>}},
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def))
+    ).


### PR DESCRIPTION
Key fields must exist in the table definition. Otherwise, an error message is returned.
