### PR TITLE
Disable symbols as table names RTS-614

### DIFF
--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -78,17 +78,6 @@ select_nested_quotes_sql_test() ->
                             #riak_sql_v1{'SELECT' = [[<<"*">>]],
                                          'FROM'   = <<"some \"quotes\" in me">>}).
 
-select_regex_sql_test() ->
-    ?sql_compilation_assert("select * from /.*/",
-                            #riak_sql_v1{'SELECT' = [[<<"*">>]],
-                                         'FROM'   = {regex, <<"/.*/">>}}).
-
-select_with_limit_sql_test() ->
-    ?sql_compilation_assert("select * from /.*/ limit 1",
-                            #riak_sql_v1{'SELECT' = [[<<"*">>]],
-                                         'FROM'   = {regex, <<"/.*/">>},
-                                         'LIMIT'  = 1}).
-
 select_from_lists_sql_test() ->
     ?sql_compilation_assert("select * from events, errors",
                             #riak_sql_v1{'SELECT' = [[<<"*">>]],
@@ -157,13 +146,6 @@ select_where_5_sql_test() ->
                                                       {'=', <<"time">>,            {integer, 1400497861762723}}
                                                      }
                                                     ]
-                                        }).
-
-select_where_7_sql_test() ->
-    ?sql_compilation_assert("select * from /.*/ limit 1",
-                            #riak_sql_v1{'SELECT' = [[<<"*">>]],
-                                         'FROM'   = {regex, <<"/.*/">>},
-                                         'LIMIT'  = 1
                                         }).
 
 select_where_8_sql_test() ->
@@ -708,15 +690,6 @@ sql_first_char_is_newline_test() ->
 %%%
 %%% Failure tests
 %%%
-
-failure_sql_test() ->
-    String = "klsdafj kljfd (*((*& 89& 8KHH kJHkj hKJH K K",
-    Expected = error,
-    Got = case parse(riak_ql_lexer:get_tokens(String)) of
-              {error, _Err} -> error;
-              Other         -> {should_not_compile, Other}
-          end,
-    ?assertEqual(Expected, Got).
 
 % RTS-388
 concatenated_unquoted_strings_test() ->

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -163,7 +163,7 @@ Rules.
 {IDENTIFIER} : {token, {identifier, list_to_binary(TokenChars)}}.
 {UNICODE} : error(unicode_in_identifier).
 
-.  : {token, {identifier, list_to_binary(TokenChars)}}.
+.  : error(iolist_to_binary(io_lib:format("Unexpected token '~s'.", [TokenChars]))).
 
 Erlang code.
 

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -108,9 +108,6 @@ Buckets -> Buckets comma Bucket : make_list('$1', '$3').
 Buckets -> Bucket               : '$1'.
 
 Bucket -> Identifier   : '$1'.
-Bucket -> regex  : '$1'.
-
-%% Word -> chars      : process('$1').
 
 Identifier -> identifier : '$1'.
 

--- a/test/lexer_tests.erl
+++ b/test/lexer_tests.erl
@@ -1,0 +1,42 @@
+-module(lexer_tests).
+
+-compile([export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("riak_ql_ddl.hrl").
+
+symbols_in_identifier_1_test() ->
+    ?assertError(
+        <<"Unexpected token '^'.">>,
+        riak_ql_lexer:get_tokens(
+            "CREATE TABLE ^ ("
+            "time TIMESTAMP NOT NULL, "
+            "family VARCHAR NOT NULL, "
+            "series VARCHAR NOT NULL, "
+            "PRIMARY KEY "
+            " ((family, series, quantum(time, 15, 's')), family, series, time))")
+    ).
+
+symbols_in_identifier_2_test() ->
+    ?assertError(
+        <<"Unexpected token '&'.">>,
+        riak_ql_lexer:get_tokens("klsdafj kljfd (*((*& 89& 8KHH kJHkj hKJH K K")
+    ).
+
+symbols_in_identifier_3_test() ->
+    ?assertError(
+        <<"Unexpected token '$'.">>,
+        riak_ql_lexer:get_tokens(
+            "CREATE TABLE mytable ("
+            "time TIMESTAMP NOT NULL, "
+            "family $ NOT NULL, "
+            "series VARCHAR NOT NULL, "
+            "PRIMARY KEY "
+            " ((family, series, quantum(time, 15, 's')), family, series, time))")
+    ).
+
+symbols_in_identifier_4_test() ->
+    ?assertError(
+        <<"Unexpected token ']'.">>,
+        riak_ql_lexer:get_tokens("select ] from a")
+    ).


### PR DESCRIPTION
Throw an error on matching dot instead of treating it as an identifier so that it cannot be used as a table name.

Removed the symbol for regex as a bucket to prevent further abuse.
