### PR TITLE
RTS-602 nullable key test

### DIFF
--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -688,7 +688,25 @@ create_all_types_sql_test() ->
                  },
     ?assertEqual(Expected, Got).
 
-create_with_nullable_key_test() ->
+create_with_timestamp_nullable_key_test() ->
+    ?sql_compilation_fail("CREATE TABLE GeoCheckin ("
+                          " geohash varchar not null,"
+                          " user varchar not null,"
+                          " time timestamp,"
+                          " weather varchar not null,"
+                          " temperature varchar,"
+                          " PRIMARY KEY ((geohash, user, quantum(time, 15, 'm')), geohash, user, time))").
+
+create_with_single_nullable_key_test() ->
+    ?sql_compilation_fail("CREATE TABLE GeoCheckin ("
+                          " geohash varchar not null,"
+                          " user varchar,"
+                          " time timestamp not null,"
+                          " weather varchar not null,"
+                          " temperature varchar,"
+                          " PRIMARY KEY ((geohash, user, quantum(time, 15, 'm')), geohash, user, time))").
+
+create_with_all_nullable_key_test() ->
     ?sql_compilation_fail("CREATE TABLE GeoCheckin ("
                           " geohash varchar,"
                           " user varchar,"


### PR DESCRIPTION
This tests that `CREATE TABLE` statements with nullable key columns produce parser errors.
