### PR TITLE
RTS-637: ranges spanning exact multiples of quanta had extra q appended

### DIFF
--- a/src/riak_ql_quanta.erl
+++ b/src/riak_ql_quanta.erl
@@ -49,13 +49,17 @@ quanta(StartTime, EndTime, QuantaSize, Unit) ->
     Start = quantum(StartTime, QuantaSize, Unit),
     case Start of
 	{error, _} = E -> E;
-	_Other         -> End = quantum(EndTime, QuantaSize, Unit),
+	_Other         -> End = EndTime,
 			  Diff = End - Start,
 			  Slice = unit_to_ms(Unit) * QuantaSize,
-			  NSlices = Diff div Slice + 1,
+			  NSlices = accommodate(Diff, Slice),
 			  Quanta = gen_quanta(NSlices, Start, Slice, []),
 			  {NSlices, Quanta}
     end.
+
+%% compute ceil(Length / Unit)
+accommodate(Length, Unit) ->
+    Length div Unit + if Length rem Unit > 0 -> 1; el/=se -> 0 end.
 
 gen_quanta(1, _Start, _Slice, Acc) ->
     Acc;


### PR DESCRIPTION
RTS-637

Previously, ranges spanning an exact multiple times of quanta resulted in an extra, empty, subquery appended in `riak_kv_qry_compiler:compile/2`.

A unit test in riak_kv is in https://github.com/basho/riak_kv/pull/1292.
