### PR TITLE
Allow equals and not equals ops in for left hand literal comparison

### DIFF
--- a/test/parser_tests.erl
+++ b/test/parser_tests.erl
@@ -250,3 +250,21 @@ time_unit_case_insensitive_test() ->
             "SELECT * FROM mytable WHERE time > 10S "
             "AND time < 20M AND time > 15H and time < 4D"))
     ).
+
+left_hand_side_literal_equals_test() ->
+    ?assertMatch(
+        {ok, #riak_sql_v1{
+            'WHERE' = [{'=', <<"age">>, {integer, 10}}]
+        }},
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytable WHERE 10 = age"))
+    ).
+
+left_hand_side_literal_not_equals_test() ->
+    ?assertMatch(
+        {ok, #riak_sql_v1{
+            'WHERE' = [{'!=', <<"age">>, {integer, 10}}]
+        }},
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytable WHERE 10 != age"))
+    ).


### PR DESCRIPTION
Previously these examples would return `function_clause` errors to the client, with no further information.

``` sql
10 = myseries
10 != myseries
```

This is because only `>`, `<`, `>=` and `<=` were handled the the `flip_comparison` function clause.
