### PR TITLE
Remove obsolete DDL validations RTS-789

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,9 @@ test: testclean compile
 DIALYZER_APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
 	xmerl webtool snmp public_key mnesia eunit syntax_tools compiler
 
+shell:
+	@# the shell command is broken in the riak_ql version of rebar and doesn't
+	@# do distribution anyway.
+	erl -pa ebin -pa deps/*/ebin -sname riak_ql -setcookie riak_ql
+
 include tools.mk

--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
-Readme
-------
+# Riak QL
 
 riak_ql provides a number of different functions to Riak
 * a lexer/parser for the SQL sub-set we support
 * a function for calculating time quanta for Time Series
 * a compiler for generating helper modules to validate and manipulate records that correspond to a defined table schema in the DDL
 
-Generated Modules
------------------
+Link to the official and still private [docs](https://github.com/basho/private_basho_docs/tree/timeseries/1.0.0/source/languages/en/riakts).
+
+### Compiling and Decompiling
+
+```
+Table_def = "CREATE TABLE MyTable (myfamily varchar not null, myseries varchar not null, time timestamp not null, weather varchar not null, temperature double, PRIMARY KEY ((myfamily, myseries, quantum(time, 10, 'm')), myfamily, myseries, time))".
+
+{ok, DDL} = riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def)).
+{ModName, AST} = riak_ql_ddl_compiler:compile(DDL).
+
+riak_ql_ddl_compiler:write_source_to_files("/tmp", DDL, AST).
+```
+
+### Generated Modules
 
 The structure and interfaces of the generated modules is shown as per this `.erl` file which has been reverse generated from the AST that riak_kv_ddl_compiler emits. The comments contain details of the fields and keys used in the creation of the DDL.
 

--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -387,7 +387,7 @@ simplest_partition_key_test() ->
                                    type     = varchar}
                    ],
                    PK),
-    {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, _Module} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Obj = {Name},
     Result = (catch get_partition_key(DDL, Obj)),
     ?assertEqual([{varchar, Name}], Result).
@@ -412,7 +412,7 @@ simple_partition_key_test() ->
                                    type     = varchar}
                    ],
                    PK),
-    {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, _Module} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Obj = {<<"one">>, <<"two">>, <<"three">>},
     Result = (catch get_partition_key(DDL, Obj)),
     ?assertEqual([{varchar, <<"three">>}, {varchar, <<"one">>}], Result).
@@ -445,7 +445,7 @@ function_partition_key_test() ->
                                    type     = varchar}
                    ],
                    PK),
-    {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, _Module} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Obj = {1234567890, <<"two">>, <<"three">>},
     Result = (catch get_partition_key(DDL, Obj)),
     %% Yes the mock partition function is actually computed
@@ -518,7 +518,7 @@ complex_partition_key_test() ->
                                    type     = Map1}
                    ],
                    PK),
-    {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, _Module} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Obj = {{2, {3}, {4}}},
     Result = (catch get_partition_key(DDL, Obj)),
     Expected = [{sint64, 2}, {poodle, mock_result}, {wombat, mock_result}],
@@ -543,7 +543,7 @@ local_key_test() ->
                                    type     = varchar}
                    ],
                    PK, LK),
-    {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, _Module} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Obj = {Name},
     Result = (catch get_local_key(DDL, Obj)),
     ?assertEqual([{varchar, Name}], Result).
@@ -570,7 +570,7 @@ simple_valid_map_get_type_1_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Module} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Result = (catch Module:get_field_type([<<"erko">>, <<"yarple">>])),
     ?assertEqual(sint64, Result).
 
@@ -592,7 +592,7 @@ simple_valid_map_get_type_2_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Module} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Result = (catch Module:get_field_type([<<"erko">>])),
     ?assertEqual(map, Result).
 
@@ -624,7 +624,7 @@ complex_valid_map_get_type_test() ->
                                    position = 1,
                                    type     = Map1}
                    ]),
-    {module, Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Module} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Path = [<<"Top_Map">>, <<"Level_1_map1">>, <<"in_Map_1">>],
     Res = (catch Module:get_field_type(Path)),
     ?assertEqual(sint64, Res).
@@ -654,7 +654,7 @@ make_plain_key_test() ->
             {<<"user">>, <<"user_1">>},
             {<<"time">>, Time}
            ],
-    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Got = make_key(Mod, Key, Vals),
     Expected = [{varchar, <<"user_1">>}, {timestamp, Time}],
     ?assertEqual(Expected, Got).
@@ -688,7 +688,7 @@ make_functional_key_test() ->
             {<<"user">>, <<"user_1">>},
             {<<"time">>, Time}
            ],
-    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Got = make_key(Mod, Key, Vals),
     Expected = [{varchar, <<"user_1">>}, {timestamp, mock_result}],
     ?assertEqual(Expected, Got).
@@ -708,7 +708,7 @@ partial_wildcard_are_selections_valid_test() ->
                                    position = 2,
                                    type     = sint64}
                    ]),
-    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     ?assertEqual(
         true,
         are_selections_valid(Mod, Selections, ?CANTBEBLANK)
@@ -726,7 +726,7 @@ partial_are_selections_valid_fail_test() ->
                                    position = 2,
                                    type     = sint64}
                    ]),
-    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     ?assertEqual(
         {false, [{selections_cant_be_blank, []}]},
         are_selections_valid(Mod, Selections, ?CANTBEBLANK)
@@ -750,7 +750,7 @@ simple_is_query_valid_test() ->
                                    position = 2,
                                    type     = sint64}
                    ]),
-    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     ?assertEqual(
         true,
         riak_ql_ddl:is_query_valid(Mod, DDL, Query)
@@ -779,7 +779,7 @@ simple_is_query_valid_map_test() ->
                                    position = 2,
                                    type     = Map}
                    ]),
-    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     ?assertEqual(
         true,
         riak_ql_ddl:is_query_valid(Mod, DDL, Query)
@@ -807,7 +807,7 @@ simple_is_query_valid_map_wildcard_test() ->
                                    position = 2,
                                    type     = Map}
                    ]),
-    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     ?assertEqual(
         true,
         riak_ql_ddl:is_query_valid(Mod, DDL, Query)
@@ -837,7 +837,7 @@ simple_filter_query_test() ->
                                    position = 2,
                                    type     = sint64}
                    ]),
-    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Res = riak_ql_ddl:is_query_valid(Mod, DDL, Query),
     ?assertEqual(true, Res).
 
@@ -873,7 +873,7 @@ full_filter_query_test() ->
                                    position = 4,
                                    type     = sint64}
                    ]),
-    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Res = riak_ql_ddl:is_query_valid(Mod, DDL, Query),
     ?assertEqual(true, Res).
 
@@ -934,7 +934,7 @@ timeseries_filter_test() ->
                   partition_key = PK,
                   local_key     = LK
                  },
-    {module, Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Res = riak_ql_ddl:is_query_valid(Mod, DDL, Query),
     Expected = true,
     ?assertEqual(Expected, Res).
@@ -950,7 +950,7 @@ is_query_valid_test_helper(Table_name, Table_def, Query) ->
     catch code:purge(Mod_name),
     DDL = test_parse(Table_def),
     % ?debugFmt("QUERY is ~p", [test_parse(Query)]),
-    {module,Mod} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module,Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     is_query_valid(Mod, DDL, test_parse(Query)).
 
 -define(LARGE_TABLE_DEF,

--- a/src/riak_ql_ddl_compiler.erl
+++ b/src/riak_ql_ddl_compiler.erl
@@ -50,24 +50,10 @@
 
 -include("riak_ql_ddl.hrl").
 
--export([
-         compile/1,
-         compile/3,
-         make_helper_mod/1,
-         make_helper_mod/2
-        ]).
+-export([compile/1]).
+-export([compile_and_load_from_tmp/1]).
+-export([write_source_to_files/3]).
 
-%% Testing only
--export([
-         mk_helper_m2/2,
-         mk_helper_m2/1
-        ]).
-
--import(riak_ql_parser, [parse/1]).
--import(riak_ql_lexer, [get_tokens/1]).
-
--define(NODEBUGOUTPUT, false).
--define(DEBUGOUTPUT,   true).
 -define(IGNORE,        true).
 -define(DONTIGNORE,    false).
 -define(NOPREFIX,      []).
@@ -85,141 +71,13 @@
 -type maps()   :: {maps, [[#riak_field_v1{}]]}.
 -type map()    :: {map,  [#riak_field_v1{}]}.
 
--spec make_helper_mod(#ddl_v1{}) -> {module, atom()} | {'error', tuple()}.
-make_helper_mod(#ddl_v1{} = DDL) ->
-    make_helper_mod(DDL, "/tmp", ?NODEBUGOUTPUT).
-
--spec make_helper_mod(#ddl_v1{}, binary()) -> {module, atom()} | {'error', tuple()}.
-make_helper_mod(#ddl_v1{} = DDL, OutputDir) ->
-    make_helper_mod(DDL, OutputDir, ?DEBUGOUTPUT).
-
-make_helper_mod(#ddl_v1{partition_key = none}, _, _) ->
-    {error, ddl_type_not_supported};
-make_helper_mod(#ddl_v1{} = DDL, Dir, IsDebugOn) ->
-    mk_helper_m2(DDL, Dir, IsDebugOn).
-
-%%
-%% this entry point is used in the test suite
-%% when the query language is fully generalised these fns
-%% will merge with make_helper_mod/N
-%%
--spec mk_helper_m2(#ddl_v1{}) -> {module, atom()} | {'error', tuple()}.
-mk_helper_m2(#ddl_v1{} = DDL) ->
-    mk_helper_m2(DDL, "/tmp", ?NODEBUGOUTPUT).
-
--spec mk_helper_m2(#ddl_v1{}, OutputDir :: string()) -> {module, atom()} | {'error', tuple()}.
-mk_helper_m2(#ddl_v1{} = DDL, OutputDir) ->
-    mk_helper_m2(DDL, OutputDir, ?DEBUGOUTPUT).
-
--spec mk_helper_m2(#ddl_v1{}, OutputDir :: string(), boolean()) ->
-			  {module, atom()} | {'error', tuple()}.
-mk_helper_m2(#ddl_v1{} = DDL, OutputDir, HasDebugOutput) ->
-    case validate_ddl(DDL) of
-        true ->
-            {Module, AST} = compile(DDL, OutputDir, HasDebugOutput),
-            {ok, Module, Bin} = compile:forms(AST),
-            SpoofBeam = "/tmp/" ++ atom_to_list(Module) ++ ".beam",
-            {module, Module} = code:load_binary(Module, SpoofBeam, Bin);
-        {false, Errs} ->
-            {error, {invalid_ddl, Errs}}
-    end.
-
-%%
-%% Funs to validate if the DDL definition is correct
-%%
-
-validate_ddl(#ddl_v1{fields = Fields}) ->
-    Ret1 = validate_fields(Fields, []),
-    Ret2 = validate_positions(Fields),
-    case lists:merge(Ret1, Ret2) of
-        []   -> true;
-        Errs -> {false, Errs}
-    end.
-
-validate_positions(Fields) ->
-    SortFn = fun(#riak_field_v1{position = A}, #riak_field_v1{position = B}) ->
-		     if
-			 A =< B -> true;
-			 A >  B -> false
-		     end
-	     end,
-    Fs2 = lists:sort(SortFn, Fields),
-    validate_pos2(Fs2, ?POSNOSTART, []).
-
-validate_pos2([], _NPos, Acc) ->
-    lists:flatten(lists:reverse(Acc));
-validate_pos2([#riak_field_v1{type     = {map, MapFields},
-                              position = NPos} | T], NPos, Acc) ->
-    NewAcc = case validate_positions(MapFields) of
-                 [] -> Acc;
-                 A  -> [A | Acc]
-             end,
-    validate_pos2(T, NPos + 1, NewAcc);
-validate_pos2([#riak_field_v1{position = NPos} | T], NPos, Acc) ->
-    validate_pos2(T, NPos + 1, Acc);
-validate_pos2([H | T], NPos, Acc) ->
-    validate_pos2(T, NPos + 1, [{wrong_position, {expected, NPos}, H} | Acc]).
-
-validate_fields([], []) ->
-    [];
-validate_fields([], Acc) ->
-    lists:flatten(lists:reverse(Acc));
-validate_fields([#riak_field_v1{name     = N,
-                                position = P,
-                                type     = Ty,
-                                optional = O} | T], Acc)
-  when is_binary(N),
-       (is_integer(P)
-        andalso P > 0),
-       (Ty == varchar
-        orelse Ty =:= sint64
-        orelse Ty =:= double
-        orelse Ty =:= boolean
-        orelse Ty =:= set
-        orelse Ty =:= timestamp
-        orelse Ty =:= any),
-       is_boolean(O) ->
-    validate_fields(T, Acc);
-validate_fields([#riak_field_v1{name     = N,
-                                position = P,
-                                type     = {map, MapFields},
-                                optional = false} | T], Acc)
-  when is_binary(N),
-       (is_integer(P)
-        andalso P > 0)
-       ->
-    NewAcc = case validate_fields(MapFields, []) of
-                 [] -> Acc;
-                 A  -> [A | Acc]
-             end,
-    validate_fields(T, NewAcc);
-validate_fields([#riak_field_v1{name     = N,
-                                position = P,
-                                type     = {map, _MapFields},
-                                optional = true} = H | T], Acc)
-  when is_binary(N),
-       (is_integer(P)
-        andalso P > 0)
-       ->
-    validate_fields(T, [{maps_cant_be_optional, H} | Acc]);
-validate_fields([H | T], Acc) ->
-    validate_fields(T, [{invalid_field, H} | Acc]).
-
-%%
-%% funs to compile the DDL to its helper module AST
-%%
-
+%% Compile the DDL to its helper module AST.
 -spec compile(#ddl_v1{}) ->
-                     {module, ast()} | {'error', tuple()}.
-compile(DDL) ->
-    Debug = false,
-    compile(DDL, << >>, Debug).
-
--spec compile(#ddl_v1{}, binary(), boolean()) ->
-                     {module, ast()} | {'error', tuple()}.
-compile(#ddl_v1{} = DDL, OutputDir, HasDebugOutput) ->
-    #ddl_v1{table         = Table,
-            fields        = Fields} = DDL,
+        {module, ast()} | {error, tuple()}.
+compile({ok, #ddl_v1{} = DDL}) ->
+    % handle output directly from riak_ql_parser
+    compile(DDL);
+compile(#ddl_v1{ table = Table, fields = Fields } = DDL) ->
     {ModName, Attrs, LineNo} = make_attrs(Table, ?LINENOSTART),
     {VFns,  LineNo2} = build_validn_fns([Fields],   LineNo,  ?POSNOSTART, [], []),
     {ACFns, LineNo3} = build_add_cols_fns(Fields, LineNo2),
@@ -229,57 +87,61 @@ compile(#ddl_v1{} = DDL, OutputDir, HasDebugOutput) ->
     {GetDDLFn, LineNo7}  = build_get_ddl_fn(DDL, LineNo6, []),
     AST = Attrs
         ++ VFns
-	++ ACFns
-        ++ [ExtractFn]
-        ++ [GetTypeFn]
-        ++ [IsValidFn]
-	++ [GetDDLFn]
-        ++ [{eof, LineNo7}],
-    if HasDebugOutput ->
-            ASTFileName = filename:join([OutputDir, ModName]) ++ ".ast",
-            write_file(ASTFileName, io_lib:format("~p", [AST]));
-       el/=se ->
-            ok
-    end,
-    Lint = erl_lint:module(AST),
-    case Lint of
+        ++ ACFns
+        ++ [ExtractFn, GetTypeFn, IsValidFn, GetDDLFn, {eof, LineNo7}],
+    case erl_lint:module(AST) of
         {ok, []} ->
-            if
-                HasDebugOutput ->
-                    SrcFileName = filename:join([OutputDir, ModName]) ++ ".erl",
-                    write_src(AST, DDL, SrcFileName);
-                el/=se ->
-                    ok
-            end,
-            _Module = {ModName, AST};
-        Other  -> exit(Other)
+            {ModName, AST};
+        Other ->
+            exit(Other)
     end.
 
-write_src(AST, DDL, SrcFileName) ->
-    AST2 = filter_ast(AST, []),
-    Syntax = erl_syntax:form_list(AST2),
-    Header = io_lib:format("%%% Generated Module, DO NOT EDIT~n~n" ++
-                               "Validates the DDL~n~n" ++
-                               "Table         : ~s~n" ++
-                               "Fields        : ~p~n" ++
-                               "Partition_Key : ~p~n" ++
-			       "Local_Key     : ~p~n~n",
-                           [
-                            binary_to_list(DDL#ddl_v1.table),
-                            DDL#ddl_v1.fields,
-                            DDL#ddl_v1.partition_key,
-			    DDL#ddl_v1.local_key
-                           ]),
-    Header2 = re:replace(Header, "\\n", "\\\n%%% ", [global, {return, list}]),
-    Src = erl_prettypr:format(Syntax),
-    Contents  = [Header2 ++ "\n" ++ Src],
-    write_file(SrcFileName, Contents).
+%% Compile the module, write it to /tmp then load it into the VM.
+-spec compile_and_load_from_tmp(#ddl_v1{}) ->
+        {module, atom()} | {error, tuple()}.
+compile_and_load_from_tmp({ok, #ddl_v1{} = DDL}) ->
+    % handle output directly from riak_ql_parser
+    compile_and_load_from_tmp(DDL);
+compile_and_load_from_tmp(#ddl_v1{} = DDL) ->
+    {Module, AST} = compile(DDL),
+    {ok, Module, Bin} = compile:forms(AST),
+    BeamFileName = "/tmp/" ++ atom_to_list(Module) ++ ".beam",
+    {module, Module} = code:load_binary(Module, BeamFileName, Bin).
 
+%% Write the AST and erlang source derived from the AST to disk for debugging.
+-spec write_source_to_files(string(), #ddl_v1{}, ast()) -> ok.
+write_source_to_files(OutputDir, #ddl_v1{ table = Table } = DDL, AST) ->
+    ModName = riak_ql_ddl:make_module_name(Table),
+    ASTFileName = filename:join([OutputDir, ModName]) ++ ".ast",
+    SrcFileName = filename:join([OutputDir, ModName]) ++ ".erl",
+    ok = write_file(ASTFileName, io_lib:format("~p", [AST])),
+    ok = write_file(SrcFileName, [
+        build_debug_header_text(DDL), "\n",
+        build_erlang_source(AST)]).
+
+%%
+build_erlang_source(AST1) ->
+    AST2 = filter_ast(AST1, []),
+    Syntax = erl_syntax:form_list(AST2),
+    erl_prettypr:format(Syntax).
+
+%%
+build_debug_header_text(#ddl_v1{ table = Table, fields = Fields,
+                                 partition_key = PartitionKey,
+                                 local_key = LocalKey }) ->
+    io_lib:format(
+        "%%% Generated Module, DO NOT EDIT~n~n"
+        "%%% Validates the DDL~n~n"
+        "%%% Table         : ~s~n"
+        "%%% Fields        : ~p~n"
+        "%%% Partition_Key : ~p~n"
+        "%%% Local_Key     : ~p~n~n",
+        [Table, Fields, PartitionKey, LocalKey ]).
+
+%%
 write_file(FileName, Contents) ->
     ok = filelib:ensure_dir(FileName),
-    {ok, Fd} = file:open(FileName, [write]),
-    io:fwrite(Fd, "~s~n", [Contents]),
-    file:close(Fd).
+    ok = file:write_file(FileName, [Contents]).
 
 filter_ast([], Acc) ->
     lists:reverse(Acc);
@@ -796,7 +658,7 @@ make_ddl(Table, Fields, #key_v1{} = PK, #key_v1{} = LK)
 
 simplest_valid_test() ->
     DDL = make_simplest_valid_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>}),
     ?assertEqual(?VALID, Result).
 
@@ -810,7 +672,7 @@ make_simplest_valid_ddl() ->
 
 simple_valid_varchar_test() ->
     DDL = make_simple_valid_varchar_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, <<"werewr">>}),
     ?assertEqual(?VALID, Result).
 
@@ -827,7 +689,7 @@ make_simple_valid_varchar_ddl() ->
 
 simple_valid_sint64_test() ->
     DDL = make_simple_valid_sint64_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({999, -9999, 0}),
     ?assertEqual(?VALID, Result).
 
@@ -847,7 +709,7 @@ make_simple_valid_sint64_ddl() ->
 
 simple_valid_double_test() ->
     DDL = make_simple_valid_double_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({432.22, -23423.22, -0.0}),
     ?assertEqual(?VALID, Result).
 
@@ -867,7 +729,7 @@ make_simple_valid_double_ddl() ->
 
 simple_valid_boolean_test() ->
     DDL = make_simple_valid_boolean_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({true, false}),
     ?assertEqual(?VALID, Result).
 
@@ -884,7 +746,7 @@ make_simple_valid_boolean_ddl() ->
 
 simple_valid_timestamp_test() ->
     DDL = make_simple_valid_timestamp_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({234324, 23424, 34636}),
     ?assertEqual(?VALID, Result).
 
@@ -904,7 +766,7 @@ make_simple_valid_timestamp_ddl() ->
 
 simple_valid_map_1_test() ->
     DDL = make_simple_valid_map_1_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, {<<"erko">>}, 4.4}),
     ?assertEqual(?VALID, Result).
 
@@ -929,7 +791,7 @@ make_simple_valid_map_1_ddl() ->
 
 simple_valid_map_2_test() ->
     DDL = make_simple_valid_map_2_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, {<<"erko">>, -999}, 4.4}),
     ?assertEqual(?VALID, Result).
 
@@ -957,7 +819,7 @@ make_simple_valid_map_2_ddl() ->
 
 simple_valid_optional_1_test() ->
     DDL = make_simple_valid_optional_1_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({[]}),
     ?assertEqual(?VALID, Result).
 
@@ -972,7 +834,7 @@ make_simple_valid_optional_1_ddl() ->
 
 simple_valid_optional_2_test() ->
     DDL = make_simple_valid_optional_2_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({[], [], [], [], [], [], []}),
     ?assertEqual(?VALID, Result).
 
@@ -1011,7 +873,7 @@ make_simple_valid_optional_2_ddl() ->
 
 simple_valid_optional_3_test() ->
     DDL = make_simple_valid_optional_3_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({[], <<"edible">>}),
     ?assertEqual(?VALID, Result).
 
@@ -1030,7 +892,7 @@ make_simple_valid_optional_3_ddl() ->
 
 complex_valid_optional_1_test() ->
     DDL = make_complex_valid_optional_1_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({[], {1, []}}),
     ?assertEqual(?VALID, Result).
 
@@ -1059,7 +921,7 @@ make_complex_valid_optional_1_ddl() ->
 
 complex_valid_map_1_test() ->
     DDL = make_complex_valid_map_1_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({1, {1, {3, 4}, 1}, 1}),
     ?assertEqual(?VALID, Result).
 
@@ -1098,7 +960,7 @@ make_complex_valid_map_1_ddl() ->
 
 complex_valid_map_2_test() ->
     DDL = make_complex_valid_map_2_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({1, {1, {1, 1, {1, 1}}, 1}, 1}),
     ?assertEqual(?VALID, Result).
 
@@ -1148,7 +1010,7 @@ make_complex_valid_map_2_ddl() ->
 
 complex_valid_map_3_test() ->
     DDL = make_complex_valid_map_3_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({{2, {3}, {4}}}),
     ?assertEqual(?VALID, Result).
 
@@ -1183,7 +1045,7 @@ make_complex_valid_map_3_ddl() ->
 
 simple_valid_any_test() ->
     DDL = make_simple_valid_any_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, [a, b, d], 4.4}),
     ?assertEqual(?VALID, Result).
 
@@ -1203,7 +1065,7 @@ make_simple_valid_any_ddl() ->
 
 simple_valid_set_test() ->
     DDL = make_simple_valid_set_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, [a, b, d], 4.4}),
     ?assertEqual(?VALID, Result).
 
@@ -1223,7 +1085,7 @@ make_simple_valid_set_ddl() ->
 
 simple_valid_mixed_test() ->
     DDL = make_simple_valid_mixed_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, 99, 4.4, 5555}),
     ?assertEqual(?VALID, Result).
 
@@ -1258,7 +1120,7 @@ simple_invalid_varchar_test() ->
                                    position = 2,
                                    type     = varchar}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, 55}),
     ?assertEqual(?INVALID, Result).
 
@@ -1275,7 +1137,7 @@ simple_invalid_sint64_test() ->
                                    position = 3,
                                    type     = sint64}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({999, -9999, 0,0}),
     ?assertEqual(?INVALID, Result).
 
@@ -1292,7 +1154,7 @@ simple_invalid_double_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({432.22, -23423.22, [a, b, d]}),
     ?assertEqual(?INVALID, Result).
 
@@ -1309,7 +1171,7 @@ simple_invalid_boolean_test() ->
                                    position = 3,
                                    type     = boolean}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({true, false, [a, b, d]}),
     ?assertEqual(?INVALID, Result).
 
@@ -1326,7 +1188,7 @@ simple_invalid_set_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, [444.44], 4.4}),
     ?assertEqual(?VALID, Result).
 
@@ -1343,7 +1205,7 @@ simple_invalid_timestamp_1_test() ->
                                    position = 3,
                                    type     = timestamp}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({234.324, 23424, 34636}),
     ?assertEqual(?INVALID, Result).
 
@@ -1360,7 +1222,7 @@ simple_invalid_timestamp_2_test() ->
                                    position = 3,
                                    type     = timestamp}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({234324, -23424, 34636}),
     ?assertEqual(?INVALID, Result).
 
@@ -1377,7 +1239,7 @@ simple_invalid_timestamp_3_test() ->
                                    position = 3,
                                    type     = timestamp}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({234324, 0, 34636}),
     ?assertEqual(?INVALID, Result).
 
@@ -1399,7 +1261,7 @@ simple_invalid_map_1_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, {99}, 4.4}),
     ?assertEqual(?INVALID, Result).
 
@@ -1424,7 +1286,7 @@ simple_invalid_map_2_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, {<<"erer">>}, 4.4}),
     ?assertEqual(?INVALID, Result).
 
@@ -1449,7 +1311,7 @@ simple_invalid_map_3_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, {<<"bingo">>, <<"bango">>, <<"erk">>}, 4.4}),
     ?assertEqual(?INVALID, Result).
 
@@ -1471,7 +1333,7 @@ simple_invalid_map_4_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>, [99], 4.4}),
     ?assertEqual(?INVALID, Result).
 
@@ -1507,7 +1369,7 @@ complex_invalid_map_1_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({<<"ewrewr">>,
 				  {<<"erko">>,
 				   {<<"yerk">>, 33.0}
@@ -1529,7 +1391,7 @@ too_small_tuple_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({432.22, -23423.22}),
     ?assertEqual(?INVALID, Result).
 
@@ -1546,90 +1408,9 @@ too_big_tuple_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({432.22, -23423.22, 44.44, 65.43}),
     ?assertEqual(?INVALID, Result).
-
-%% invalid DDL tests
-
-simple_invalid_position_test() ->
-    Duff = #riak_field_v1{name     = <<"erkle">>,
-                          position = 4,
-                          type     = double},
-    DDL = make_ddl(<<"simple_invalid_position_test">>,
-                   [
-                    #riak_field_v1{name     = <<"yando">>,
-                                   position = 1,
-                                   type     = double},
-                    #riak_field_v1{name     = <<"erko">>,
-                                   position = 2,
-                                   type     = double},
-                    Duff
-                   ]),
-    {error, Err} = mk_helper_m2(DDL),
-    Expected = {invalid_ddl, [{wrong_position, {expected, 3}, Duff}]},
-    ?assertEqual(Expected, Err).
-
-simple_invalid_vals_test() ->
-    Duff = #riak_field_v1{name     = oops_atom,
-                          position = 1.0,
-                          type     = random},
-    DDL = make_ddl(<<"simple_invalid_vals_test">>,
-                   [
-                    Duff
-                   ]),
-    {error, Err} = mk_helper_m2(DDL),
-    Expected = {invalid_ddl, [{invalid_field, Duff},
-                              {wrong_position, {expected, 1}, Duff}]},
-    ?assertEqual(Expected, Err).
-
-simple_invalid_optional_test() ->
-    Map = {map, [
-                 #riak_field_v1{name     = <<"yando">>,
-                                position = 1,
-                                type     = sint64,
-                                optional = true}
-                ]},
-    Duff = #riak_field_v1{name     = <<"ribbit">>,
-                          position = 1,
-                          type     = Map,
-                          optional = true},
-    DDL = make_ddl(<<"simple_invalid_optional_test">>,
-                   [
-                    Duff
-                   ]),
-    {error, Err} = mk_helper_m2(DDL),
-    Expected = {invalid_ddl, [{maps_cant_be_optional, Duff}]},
-    ?assertEqual(Expected, Err).
-
-
-complex_invalid_vals_test() ->
-    Duff =  #riak_field_v1{name     = bert,
-                           position = 33,
-                           type     = shubert,
-                           optional = true},
-    Map = {map, [
-                 #riak_field_v1{name     = <<"yando">>,
-                                position = 1,
-                                type     = sint64,
-                                optional = true},
-                 Duff
-                ]},
-    DDL = make_ddl(<<"complex_invalid_vals_test">>,
-                   [
-                    #riak_field_v1{name     = <<"yando">>,
-                                   position = 1,
-                                   type     = varchar,
-                                   optional = true},
-                    #riak_field_v1{name     = <<"yando">>,
-                                   position = 2,
-                                   type     = Map,
-                                   optional = false}
-                   ]),
-    {error, Err} = mk_helper_m2(DDL),
-    Expected = {invalid_ddl, [{invalid_field, Duff},
-                              {wrong_position, {expected, 2}, Duff}]},
-    ?assertEqual(Expected, Err).
 
 %%
 %% Extract tests
@@ -1642,7 +1423,7 @@ simplest_valid_extract_test() ->
                                    position = 1,
                                    type     = varchar}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Obj = {<<"yarble">>},
     Result = (catch Module:extract(Obj, [<<"yando">>])),
     ?assertEqual(<<"yarble">>, Result).
@@ -1657,7 +1438,7 @@ simple_valid_extract_test() ->
                                    position = 2,
                                    type     = varchar}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Obj = {44, <<"yarble">>},
     Result = (catch Module:extract(Obj, [<<"yando">>])),
     ?assertEqual(<<"yarble">>, Result).
@@ -1680,7 +1461,7 @@ simple_valid_map_extract_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Obj = {<<"erk">>, {<<"jibjib">>}, 3.0},
     Result = (catch Module:extract(Obj, [<<"erko">>, <<"yarple">>])),
     ?assertEqual(<<"jibjib">>, Result).
@@ -1713,7 +1494,7 @@ complex_valid_map_extract_test() ->
                                    position = 1,
                                    type     = Map1}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Obj = {{2, {3}, {4}}},
     Path = [<<"Top_Map">>, <<"Level_1_map1">>, <<"in_Map_1">>],
     Res = (catch Module:extract(Obj, Path)),
@@ -1721,7 +1502,7 @@ complex_valid_map_extract_test() ->
 
 complex_ddl_test() ->
     DDL = make_complex_ddl_ddl(),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:validate_obj({12345, <<"beeees">>}),
     ?assertEqual(?VALID, Result).
 
@@ -1787,7 +1568,7 @@ simple_valid_map_add_cols_test() ->
                                    position = 3,
                                    type     = double}
                    ]),
-    {module, Module} = mk_helper_m2(DDL),
+    {module, Module} = compile_and_load_from_tmp(DDL),
     Result = Module:add_column_info({1, {2, 3}, 4}),
     Expected = [{<<"yando">>, 1}, {<<"erko">>, [
 						{<<"yarple">>, 2},
@@ -1802,7 +1583,7 @@ simple_valid_map_add_cols_test() ->
 
 -define(ddl_roundtrip_assert(MakeDDLFunName),
 	DDL = erlang:apply(?MODULE, MakeDDLFunName, []),
-	{module, Module} = mk_helper_m2(DDL),
+	{module, Module} = compile_and_load_from_tmp(DDL),
 	Got = Module:get_ddl(),
 	?assertEqual(DDL, Got)).
 

--- a/test/compiler_basic_1.erl
+++ b/test/compiler_basic_1.erl
@@ -34,13 +34,13 @@
 
 %%
 %% this test calls into the PRIVATE interface
-%% mk_helper_m2/1
+%% compile_and_load_from_tmp/1
 %%
 -define(passing_test(Name, Query, Val, ExpectedPK, ExpectedLK),
         Name() ->
                Lexed = riak_ql_lexer:get_tokens(Query),
                {ok, DDL} = riak_ql_parser:parse(Lexed),
-               case riak_ql_ddl_compiler:mk_helper_m2(DDL, "/tmp") of
+               case riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL) of
                    {module, Module}  ->
                        Result = Module:validate_obj(Val),
                        GotPK = riak_ql_ddl:get_partition_key(DDL, Val),
@@ -57,7 +57,7 @@
         Name() ->
                Lexed = riak_ql_lexer:get_tokens(Query),
                {ok, DDL} = riak_ql_parser:parse(Lexed),
-               case riak_ql_ddl_compiler:mk_helper_m2(DDL) of
+               case riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL) of
                    {module, Module}  ->
                        Result = Module:validate_obj(Val),
                        ?assertEqual(?VALID, Result);
@@ -69,13 +69,13 @@
 
 %%
 %% this test calls into the PRIVATE interface
-%% mk_helper_m2/1
+%% compile_and_load_from_tmp/1
 %%
 -define(failing_test(Name, Query, Val),
         Name() ->
                Lexed = riak_ql_lexer:get_tokens(Query),
                {ok, DDL} = riak_ql_parser:parse(Lexed),
-               case riak_ql_ddl_compiler:mk_helper_m2(DDL) of
+               case riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL) of
                    {module, Module}  ->
                        Result = Module:validate_obj(Val),
                        ?assertEqual(?INVALID, Result);
@@ -86,13 +86,13 @@
 
 %%
 %% this test calls in the PUBLIC interface
-%% make_helper_mod/1
+%% compile_and_load_from_tmp/1
 %%
 -define(not_valid_test(Name, Query),
         Name() ->
                Lexed = riak_ql_lexer:get_tokens(Query),
                {ok, DDL} = riak_ql_parser:parse(Lexed),
-               case riak_ql_ddl_compiler:make_helper_mod(DDL) of
+               case riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL) of
                    {error, _} ->
                        ?assertEqual(?VALID, true);
                    Other ->
@@ -109,7 +109,7 @@
                Lexed = riak_ql_lexer:get_tokens(Query),
                {ok, DDL} = riak_ql_parser:parse(Lexed),
                %% ?debugFmt("in ~p~n- DDL is:~n -~p~n", [Name, DDL]),
-               {module, Module} = riak_ql_ddl_compiler:mk_helper_m2(DDL),
+               {module, Module} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
                Got = Module:get_ddl(),
                %% ?debugFmt("in ~p~n- Got is:~n -~p~n", [Name, Got]),
                ?assertEqual(DDL, Got)).

--- a/test/query_ddl.erl
+++ b/test/query_ddl.erl
@@ -43,7 +43,7 @@
 run_test(Name, CreateTable, SQLQuery, IsValid) ->
     Lexed = riak_ql_lexer:get_tokens(CreateTable),
     {ok, DDL} = riak_ql_parser:parse(Lexed),
-    case riak_ql_ddl_compiler:mk_helper_m2(DDL) of
+    case riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL) of
         {module, Module} ->
             Lexed2 = riak_ql_lexer:get_tokens(SQLQuery),
             Qry = riak_ql_parser:parse(Lexed2),


### PR DESCRIPTION
DDL validation is now done in the riak_ql_parser and not the riak_ql_ddl_compiler module. The validations in the compiler are removed.

To make source printing more obvious, it is moved into it's own function `riak_ql_ddl_compiler:write_source_to_files/3` and is not a side effect of the `riak_ql_ddl_compiler:compile /1` function.
