### PR TITLE
Fix hanging on query parsing when two clauses are equal RTS-788

### DIFF
--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -460,9 +460,14 @@ canon2({Cond, A, B}) when Cond =:= and_ orelse
     %% but our where clauses are bounded in size so thats OK
     A1 = canon2(A),
     B1 = canon2(B),
-    case is_lower(A1, B1) of
-        true  -> {Cond, A1, B1};
-        false -> {Cond, B1, A1}
+    case A1 == B1 of
+        true ->
+            A1;
+        false ->
+            case is_lower(A1, B1) of
+                true  -> {Cond, A1, B1};
+                false -> {Cond, B1, A1}
+            end
     end;
 canon2({Op, A, B}) ->
     {Op, strip(A), strip(B)};
@@ -496,13 +501,17 @@ hoist({A, B, C}) ->
 %% not tail recursive
 sort({and_, A, {and_, B, C}}) ->
     case is_lower(A, B) of
-        true  -> {and_, B1, C1} = sort({and_, B, C}),
-                 case is_lower(A, B1) of
-                     true  -> {and_, A, {and_, B1, C1}};
-                     false -> sort({and_, B1, {and_, A, C1}})
-                 end;
-        false -> sort({and_, B, sort({and_, A, C})})
+        true ->
+            {and_, B1, C1} = sort({and_, B, C}),
+            case is_lower(A, B1) of
+                true  -> {and_, A, {and_, B1, C1}};
+                false -> sort({and_, B1, {and_, A, C1}})
+            end;
+        false ->
+            sort({and_, B, sort({and_, A, C})})
     end;
+sort({and_, A, A}) ->
+    A;
 sort({Op, A, B}) ->
     case is_lower(A, B) of
         true  -> {Op, A, B};

--- a/test/parser_tests.erl
+++ b/test/parser_tests.erl
@@ -283,3 +283,60 @@ infinite_loop_test_() ->
                     "and myfamily = 'family1' and myseries = 'series1' "))
             )
         end}.
+
+remove_duplicate_clauses_1_test() ->
+  ?assertEqual(
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE time > 1234567 ")),
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE time > 1234567 AND time > 1234567"))
+    ).
+
+remove_duplicate_clauses_2_test() ->
+  ?assertEqual(
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE time > 1234567 ")),
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE time > 1234567 AND time > 1234567 AND time > 1234567 "))
+    ).
+
+remove_duplicate_clauses_3_test() ->
+  ?assertEqual(
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE time > 1234567 ")),
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE time > 1234567 AND time > 1234567 OR time > 1234567 "))
+    ).
+
+remove_duplicate_clauses_4_test() ->
+  ?assertEqual(
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE time > 1234567 ")),
+        riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE time > 1234567 AND (time > 1234567 OR time > 1234567) "))
+    ).
+
+% This fails. de-duping does not yet go through the entire tree and
+% pull out duplicates
+% remove_duplicate_clauses_5_test() ->
+%   ?assertEqual(
+%         riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+%             "SELECT * FROM mytab "
+%             "WHERE time > 1234567 "
+%             "AND (localtion > 'derby' OR time > 'sheffield') "
+%             "AND weather = 'raining' ")),
+%         riak_ql_parser:parse(riak_ql_lexer:get_tokens(
+%             "SELECT * FROM mytab "
+%             "WHERE time > 1234567 "
+%             "AND (localtion > 'derby' OR time > 'sheffield') "
+%             "AND weather = 'raining' "
+%             "AND time > 1234567 "))
+%     ).


### PR DESCRIPTION
Previous to this change, queries such as the following would put `riak_ql_parser` into an infinite loop.

``` sql
SELECT myseries, temperature FROM GeoCheckin2
WHERE time > 1234567 AND time > 1234567
AND myfamily = 'family1' AND myseries = 'series1'
AND (temperature >= 23.5 OR temperature < 18.0)
```

This is because `riak_ql_parser:sort/1` did not account for clauses that were equal.  This change also removes some duplicate clauses where the clauses are next to each other, but not when they are not adjacent in there where clause.  The duplicate clause in the following statement will not be removed.

``` sql
SELECT * FROM mytab 
WHERE time > 1234567 AND (location = 'derby' OR time > 1234567)
```
