### PR TITLE
support optional WITH keyword to set table properties with CREATE TABLE (#ddl_v2{})

### DIFF
--- a/include/riak_ql_ddl.hrl
+++ b/include/riak_ql_ddl.hrl
@@ -1,8 +1,8 @@
 %% -------------------------------------------------------------------
 %%
-%% riak_kv_ddl: defines records used in the data description language
+%% riak_ql_ddl.hrl: defines records used in the data description language
 %%
-%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2015, 2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -46,7 +46,7 @@
           fn        :: atom(),
           args = [] :: [#param_v1{} | any()],
           type      :: field_type()
-	 }).
+         }).
 
 -record(key_v1, {
           ast = [] :: [#hash_fn_v1{} | #param_v1{}]
@@ -57,6 +57,14 @@
           fields        = [] :: [#riak_field_v1{}],
           partition_key      :: #key_v1{} | none,
           local_key          :: #key_v1{}
+         }).
+
+-record(ddl_v2, {
+          table              :: binary(),
+          fields        = [] :: [#riak_field_v1{}],
+          partition_key      :: #key_v1{} | none,
+          local_key          :: #key_v1{},
+          properties    = [] :: proplists:proplist()
          }).
 
 %% TODO these types will be improved over the duration of the time series project
@@ -81,7 +89,7 @@
 %% returns one row calculated from the result set for the query.
 -type select_result_type() :: rows | aggregate.
 
--record(riak_sel_clause_v1, 
+-record(riak_sel_clause_v1,
         {
           calc_type        = rows :: select_result_type(),
           initial_state    = []   :: [any()],
@@ -116,5 +124,8 @@
 
 -define(SQL_SELECT, #riak_select_v1).
 -define(SQL_SELECT_RECORD_NAME, riak_select_v1).
+
+-define(DDL, #ddl_v2).
+-define(DDL_RECORD_NAME, ddl_v2).
 
 -endif.

--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -29,7 +29,7 @@
          make_module_name/1, make_module_name/2
         ]).
 
--type ddl() :: #ddl_v1{}.
+-type ddl() :: ?DDL{}.
 -export_type([ddl/0]).
 
 
@@ -46,6 +46,7 @@
 %%-export([get_return_types_and_col_names/2]).
 -export([make_key/3]).
 -export([syntax_error_to_msg/1]).
+-export([upgrade/1, upgrade/2, downgrade/1, downgrade/2]).
 
 -type query_syntax_error() ::
         {bucket_type_mismatch, DDL_bucket::binary(), Query_bucket::binary()} |
@@ -57,6 +58,8 @@
 
 -export_type([query_syntax_error/0]).
 
+-type all_ddl_versions() :: #ddl_v1{} | #ddl_v2{}.
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 %% for debugging only
@@ -65,6 +68,41 @@
 
 -define(CANBEBLANK,  true).
 -define(CANTBEBLANK, false).
+
+%% ddl record conversions
+-spec upgrade(all_ddl_versions(), v1 | v2) -> ?DDL{}.
+upgrade(#ddl_v2{} = DDL, v2) ->
+    DDL;
+upgrade(#ddl_v1{table = Table,
+                fields = Fields,
+                partition_key = PK,
+                local_key = LK},
+        v2) ->
+    ?DDL{table = Table,
+         fields = Fields,
+         partition_key = PK,
+         local_key = LK,
+         properties = []}.
+
+upgrade(X) ->
+    upgrade(X, v2).
+
+-spec downgrade(all_ddl_versions()) -> all_ddl_versions().
+downgrade(#ddl_v1{} = DDL, v1) ->
+    DDL;
+downgrade(#ddl_v2{table = Table,
+                  fields = Fields,
+                  partition_key = PK,
+                  local_key = LK},
+          v1) ->
+    #ddl_v1{table = Table,
+            fields = Fields,
+            partition_key = PK,
+            local_key = LK}.
+
+downgrade(X) ->
+    downgrade(X, v1).
+
 
 -spec make_module_name(Table::binary()) ->
                               module().
@@ -92,26 +130,26 @@ maybe_mangle_char(C) ->
     <<$%, (list_to_binary(integer_to_list(C)))/binary>>.
 
 
--spec get_partition_key(#ddl_v1{}, tuple(), module()) -> term().
-get_partition_key(#ddl_v1{partition_key = PK}, Obj, Mod)
+-spec get_partition_key(?DDL{}, tuple(), module()) -> term().
+get_partition_key(?DDL{partition_key = PK}, Obj, Mod)
   when is_tuple(Obj) ->
     #key_v1{ast = Params} = PK,
     _Key = build(Params, Obj, Mod, []).
 
--spec get_partition_key(#ddl_v1{}, tuple()) -> term().
-get_partition_key(#ddl_v1{table = T}=DDL, Obj)
+-spec get_partition_key(?DDL{}, tuple()) -> term().
+get_partition_key(?DDL{table = T}=DDL, Obj)
   when is_tuple(Obj) ->
     Mod = make_module_name(T),
     get_partition_key(DDL, Obj, Mod).
 
--spec get_local_key(#ddl_v1{}, tuple(), module()) -> term().
-get_local_key(#ddl_v1{local_key = LK}, Obj, Mod)
+-spec get_local_key(?DDL{}, tuple(), module()) -> term().
+get_local_key(?DDL{local_key = LK}, Obj, Mod)
   when is_tuple(Obj) ->
     #key_v1{ast = Params} = LK,
     _Key = build(Params, Obj, Mod, []).
 
--spec get_local_key(#ddl_v1{}, tuple()) -> term().
-get_local_key(#ddl_v1{table = T}=DDL, Obj)
+-spec get_local_key(?DDL{}, tuple()) -> term().
+get_local_key(?DDL{table = T}=DDL, Obj)
   when is_tuple(Obj) ->
     Mod = make_module_name(T),
     get_local_key(DDL, Obj, Mod).
@@ -212,9 +250,9 @@ syntax_error_to_msg2({unknown_column_type, Other}) ->
 unquote_fn(Fn) when is_atom(Fn) ->
     string:strip(atom_to_list(Fn), both, $').
 
--spec is_query_valid(module(), #ddl_v1{}, ?SQL_SELECT{}) ->
+-spec is_query_valid(module(), ?DDL{}, ?SQL_SELECT{}) ->
                             true | {false, [query_syntax_error()]}.
-is_query_valid(_, #ddl_v1{ table = T1 },
+is_query_valid(_, ?DDL{ table = T1 },
                ?SQL_SELECT{ 'FROM' = T2 }) when T1 =/= T2 ->
     {false, [{bucket_type_mismatch, {T1, T2}}]};
 is_query_valid(Mod, _,
@@ -404,10 +442,10 @@ make_ddl(Table, Fields, PK) when is_binary(Table) ->
 
 make_ddl(Table, Fields, #key_v1{} = PK, #key_v1{} = LK)
   when is_binary(Table) ->
-    #ddl_v1{table         = Table,
-            fields        = Fields,
-            partition_key = PK,
-            local_key     = LK}.
+    ?DDL{table         = Table,
+         fields        = Fields,
+         partition_key = PK,
+         local_key     = LK}.
 
 %%
 %% get partition_key tests
@@ -967,20 +1005,21 @@ timeseries_filter_test() ->
                         #param_v1{name = [<<"time">>]},
                         #param_v1{name = [<<"user">>]}]
                 },
-    DDL = #ddl_v1{table         = <<"timeseries_filter_test">>,
-                  fields        = Fields,
-                  partition_key = PK,
-                  local_key     = LK
-                 },
+    DDL = ?DDL{table         = <<"timeseries_filter_test">>,
+               fields        = Fields,
+               partition_key = PK,
+               local_key     = LK
+              },
     {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     Res = riak_ql_ddl:is_query_valid(Mod, DDL, Query),
     Expected = true,
     ?assertEqual(Expected, Res).
 
 test_parse(SQL) ->
-    element(2,
-            riak_ql_parser:parse(
-              riak_ql_lexer:get_tokens(SQL))).
+    {ok, Parsed} =
+        riak_ql_parser:parse(
+          riak_ql_lexer:get_tokens(SQL)),
+    Parsed.
 
 is_query_valid_test_helper(Table_name, Table_def, Query) ->
     Mod_name = make_module_name(iolist_to_binary(Table_name)),

--- a/src/riak_ql_ddl_compiler.erl
+++ b/src/riak_ql_ddl_compiler.erl
@@ -72,12 +72,12 @@
 -type map()    :: {map,  [#riak_field_v1{}]}.
 
 %% Compile the DDL to its helper module AST.
--spec compile(#ddl_v1{}) ->
+-spec compile(?DDL{}) ->
         {module, ast()} | {error, tuple()}.
-compile({ok, #ddl_v1{} = DDL}) ->
+compile({ok, ?DDL{} = DDL}) ->
     % handle output directly from riak_ql_parser
     compile(DDL);
-compile(#ddl_v1{ table = Table, fields = Fields } = DDL) ->
+compile(?DDL{ table = Table, fields = Fields } = DDL) ->
     {ModName, Attrs, LineNo} = make_attrs(Table, ?LINENOSTART),
     {VFns,  LineNo2} = build_validn_fns([Fields],   LineNo,  ?POSNOSTART, [], []),
     {ACFns, LineNo3} = build_add_cols_fns(Fields, LineNo2),
@@ -97,20 +97,20 @@ compile(#ddl_v1{ table = Table, fields = Fields } = DDL) ->
     end.
 
 %% Compile the module, write it to /tmp then load it into the VM.
--spec compile_and_load_from_tmp(#ddl_v1{}) ->
+-spec compile_and_load_from_tmp(?DDL{}) ->
         {module, atom()} | {error, tuple()}.
-compile_and_load_from_tmp({ok, #ddl_v1{} = DDL}) ->
+compile_and_load_from_tmp({ok, ?DDL{} = DDL}) ->
     % handle output directly from riak_ql_parser
     compile_and_load_from_tmp(DDL);
-compile_and_load_from_tmp(#ddl_v1{} = DDL) ->
+compile_and_load_from_tmp(?DDL{} = DDL) ->
     {Module, AST} = compile(DDL),
     {ok, Module, Bin} = compile:forms(AST),
     BeamFileName = "/tmp/" ++ atom_to_list(Module) ++ ".beam",
     {module, Module} = code:load_binary(Module, BeamFileName, Bin).
 
 %% Write the AST and erlang source derived from the AST to disk for debugging.
--spec write_source_to_files(string(), #ddl_v1{}, ast()) -> ok.
-write_source_to_files(OutputDir, #ddl_v1{ table = Table } = DDL, AST) ->
+-spec write_source_to_files(string(), ?DDL{}, ast()) -> ok.
+write_source_to_files(OutputDir, ?DDL{ table = Table } = DDL, AST) ->
     ModName = riak_ql_ddl:make_module_name(Table),
     ASTFileName = filename:join([OutputDir, ModName]) ++ ".ast",
     SrcFileName = filename:join([OutputDir, ModName]) ++ ".erl",
@@ -126,9 +126,9 @@ build_erlang_source(AST1) ->
     erl_prettypr:format(Syntax).
 
 %%
-build_debug_header_text(#ddl_v1{ table = Table, fields = Fields,
-                                 partition_key = PartitionKey,
-                                 local_key = LocalKey }) ->
+build_debug_header_text(?DDL{table = Table, fields = Fields,
+                             partition_key = PartitionKey,
+                             local_key = LocalKey}) ->
     io_lib:format(
         "%%% Generated Module, DO NOT EDIT~n~n"
         "%%% Validates the DDL~n~n"
@@ -168,7 +168,7 @@ make_extract_cls([], LineNo, _Prefix, Acc) ->
 make_extract_cls([#riak_field_v1{type = Ty} = H | T], LineNo, Prefix, Acc) ->
     NPref  = [H | Prefix],
     Args   = [make_string(binary_to_list(Nm), LineNo)
-	      || #riak_field_v1{name = Nm} <- NPref],
+              || #riak_field_v1{name = Nm} <- NPref],
     Poses  = [make_integer(P,  LineNo) || #riak_field_v1{position = P}  <- NPref],
     Conses = make_conses(Args, LineNo, {nil, LineNo}),
     Var    = make_var('Obj', LineNo),
@@ -188,27 +188,30 @@ make_extract_cls([#riak_field_v1{type = Ty} = H | T], LineNo, Prefix, Acc) ->
     make_extract_cls(T, NewLineNo, Prefix, NewA).
 
 %% this is gnarly because the field order is compile-time dependent
--spec build_get_ddl_fn(#ddl_v1{}, pos_integer(), ast()) ->
-			      {expr(), pos_integer()}.
-build_get_ddl_fn(#ddl_v1{table         = T,
-			 fields        = F,
-			 partition_key = PK,
-			 local_key     = LK}, LineNo, []) ->
-    PosT  = #ddl_v1.table,
-    PosF  = #ddl_v1.fields,
-    PosPK = #ddl_v1.partition_key,
-    PosLK = #ddl_v1.local_key,
+-spec build_get_ddl_fn(?DDL{}, pos_integer(), ast()) ->
+                              {expr(), pos_integer()}.
+build_get_ddl_fn(?DDL{table         = T,
+                      fields        = F,
+                      partition_key = PK,
+                      local_key     = LK,
+                      properties    = Props}, LineNo, []) ->
+    PosT     = ?DDL.table,
+    PosF     = ?DDL.fields,
+    PosPK    = ?DDL.partition_key,
+    PosLK    = ?DDL.local_key,
+    PosProps = ?DDL.properties,
     %% the order is dependent on the order the fields are listed in the record at
     %% compile time hence this rather obscure dance of the positions
     %% The record name is deliberatly put last in the list to check it is
     %% actually working ;-)
-    {_Poses, List} = lists:unzip(lists:sort([
-					     {PosT,  make_binary(T, LineNo)},
-					     {PosF,  expand_fields(F, LineNo)},
-					     {PosPK, expand_key(PK, LineNo)},
-					     {PosLK, expand_key(LK, LineNo)},
-					     {1,     make_atom(ddl_v1, LineNo)}
-					    ])),
+    {_Poses, List} =
+        unzip_sorted(
+          [{PosT,  make_binary(T, LineNo)},
+           {PosF,  expand_fields(F, LineNo)},
+           {PosPK, expand_key(PK, LineNo)},
+           {PosLK, expand_key(LK, LineNo)},
+           {PosProps, expand_args(Props, LineNo)},
+           {1,     make_atom(?DDL_RECORD_NAME, LineNo)}]),
     Body = make_tuple(List, LineNo),
     Cl = make_clause([], [], Body, LineNo),
     Fn = make_fun(get_ddl, 0, [Cl], LineNo),
@@ -219,26 +222,26 @@ expand_fields(Fs, LineNo) ->
     make_conses(lists:reverse(Fields), LineNo, {nil, LineNo}).
 
 expand_field(#riak_field_v1{name     = Nm,
-			    position = Pos,
-			    type     = Ty,
-			    optional = Opt}, LineNo) ->
+                            position = Pos,
+                            type     = Ty,
+                            optional = Opt}, LineNo) ->
     PosNm  =  #riak_field_v1.name,
     PosPos =  #riak_field_v1.position,
     PosTy  =  #riak_field_v1.type,
-    PosOpt = #riak_field_v1.optional,
-    {_Poses, List} = lists:unzip(lists:sort([
-					     {PosNm,  make_binary(Nm, LineNo)},
-					     {PosPos, make_integer(Pos, LineNo)},
-					     {PosTy,  expand_type(Ty, LineNo)},
-					     {PosOpt, make_atom(Opt, LineNo)},
-					     {1,      make_atom(riak_field_v1, LineNo)}
-					    ])),
+    PosOpt =  #riak_field_v1.optional,
+    {_Poses, List} =
+        unzip_sorted(
+            [{PosNm,  make_binary(Nm, LineNo)},
+             {PosPos, make_integer(Pos, LineNo)},
+             {PosTy,  expand_type(Ty, LineNo)},
+             {PosOpt, make_atom(Opt, LineNo)},
+             {1,      make_atom(riak_field_v1, LineNo)}]),
     make_tuple(List, LineNo).
 
 expand_key(none, LineNo) ->
     make_atom(none, LineNo);
 expand_key(#key_v1{ast = []}, LineNo) ->
-    make_tuple([make_atom(key_v1, LineNo) ,{nil, LineNo}], LineNo);
+    make_tuple([make_atom(key_v1, LineNo), {nil, LineNo}], LineNo);
 expand_key(#key_v1{ast = AST}, LineNo) ->
     Rest = expand_ast(AST, LineNo),
     make_tuple([make_atom(key_v1, LineNo) | [Rest]], LineNo).
@@ -252,20 +255,20 @@ expand_a2(#param_v1{name = Nm}, LineNo) ->
     Conses = make_conses(Bins, LineNo, {nil, LineNo}),
     make_tuple([make_atom(param_v1, LineNo) | [Conses]], LineNo);
 expand_a2(#hash_fn_v1{mod  = Mod,
-		      fn   = Fn,
-		      args = Args,
-		      type = Ty}, LineNo) ->
+                      fn   = Fn,
+                      args = Args,
+                      type = Ty}, LineNo) ->
     PosMod  = #hash_fn_v1.mod,
     PosFn   = #hash_fn_v1.fn,
     PosArgs = #hash_fn_v1.args,
     PosType = #hash_fn_v1.type,
-    {_Pos, List} = lists:unzip(lists:sort([
-					   {PosMod,  make_atom(Mod, LineNo)},
-					   {PosFn,   make_atom(Fn, LineNo)},
-					   {PosArgs, expand_args(Args, LineNo)},
-					   {PosType, make_atom(Ty, LineNo)},
-					   {1,       make_atom(hash_fn_v1, LineNo)}
-					  ])),
+    {_Pos, List} =
+        unzip_sorted(
+          [{PosMod,  make_atom(Mod, LineNo)},
+           {PosFn,   make_atom(Fn, LineNo)},
+           {PosArgs, expand_args(Args, LineNo)},
+           {PosType, make_atom(Ty, LineNo)},
+           {1,       make_atom(hash_fn_v1, LineNo)}]),
     make_tuple(List, LineNo).
 
 expand_args(Args, LineNo) ->
@@ -285,7 +288,12 @@ expand_args2(Arg, LineNo) when is_float(Arg) ->
 expand_args2(Arg, LineNo) when is_list(Arg) ->
     make_string(Arg, LineNo);
 expand_args2(Arg, LineNo) when is_atom(Arg) ->
-    make_atom(Arg, LineNo).
+    make_atom(Arg, LineNo);
+%% this is used to create the table property list
+expand_args2({P, V}, LineNo) ->
+    make_tuple([expand_args2(P, LineNo),
+                expand_args2(V, LineNo)], LineNo).
+
 
 expand_type({map, Fs}, LineNo) ->
     Fields = lists:reverse([expand_field(X, LineNo) || X <- Fs]),
@@ -295,7 +303,7 @@ expand_type(Type, LineNo) ->
     make_atom(Type, LineNo).
 
 -spec build_is_valid_fn([[#riak_field_v1{}]], pos_integer(), ast()) ->
-			       {expr(), pos_integer()}.
+                               {expr(), pos_integer()}.
 build_is_valid_fn([], LineNo, Acc) ->
     {Fail, NewLineNo} = make_fail_clause(LineNo),
     Clauses = lists:flatten(lists:reverse([Fail | Acc])),
@@ -308,7 +316,7 @@ build_is_valid_fn([Fields | T], LineNo, Acc) ->
 make_is_valid_cls([], LineNo, Prefix, Acc) ->
     %% handle the prefixes slightly differently here than to the next clause
     Args = [make_string(binary_to_list(Nm), LineNo)
-	    || #riak_field_v1{name = Nm} <- Prefix],
+            || #riak_field_v1{name = Nm} <- Prefix],
     WildArgs = [make_string("*", LineNo) | Args],
     WildConses = make_conses(WildArgs, LineNo, {nil, LineNo}),
     Body = make_atom(true, LineNo),
@@ -319,7 +327,7 @@ make_is_valid_cls([#riak_field_v1{type = Ty} = H | T], LineNo, Prefix, Acc) ->
     %% handle the prefixes slightly differently here than to the perviousls clause
     NPref  = [H | Prefix],
     Args   = [make_string(binary_to_list(Nm), LineNo)
-	      || #riak_field_v1{name = Nm} <- NPref],
+              || #riak_field_v1{name = Nm} <- NPref],
     Conses = make_conses(Args, LineNo, {nil, LineNo}),
     %% you need to reverse the lists of the positions to
     %% get the calls to element to nest correctly
@@ -337,7 +345,7 @@ make_is_valid_cls([#riak_field_v1{type = Ty} = H | T], LineNo, Prefix, Acc) ->
     make_is_valid_cls(T, NewLineNo, Prefix, NewA).
 
 -spec build_get_type_fn([[#riak_field_v1{}]], pos_integer(), ast()) ->
-			       {expr(), pos_integer()}.
+                               {expr(), pos_integer()}.
 build_get_type_fn([], LineNo, Acc) ->
     Clauses = lists:flatten(lists:reverse(Acc)),
     Fn = make_fun(get_field_type, 1, Clauses, LineNo),
@@ -351,14 +359,14 @@ make_get_type_cls([], LineNo, _Prefix, Acc) ->
 make_get_type_cls([#riak_field_v1{type = Ty} = H | T], LineNo, Prefix, Acc) ->
     NPref  = [H | Prefix],
     Args   = [make_string(binary_to_list(Nm), LineNo)
-	      || #riak_field_v1{name = Nm} <- NPref],
+              || #riak_field_v1{name = Nm} <- NPref],
     Conses = make_conses(Args, LineNo, {nil, LineNo}),
     %% you need to reverse the lists of the positions to
     %% get the calls to element to nest correctly
     Body = case Ty of
-	       {map, _}  -> make_atom(map, LineNo);
-	       _         -> make_atom(Ty, LineNo)
-	   end,
+               {map, _}  -> make_atom(map, LineNo);
+               _         -> make_atom(Ty, LineNo)
+           end,
     Guard = [],
     Cl = make_clause([Conses], Guard, Body, LineNo),
     {NewA, NewLineNo} =
@@ -393,7 +401,7 @@ make_ar2([], LineNo, Acc1, Acc2) ->
     {make_tuple(lists:flatten(lists:reverse(Acc1)), LineNo),
      make_conses(lists:flatten(Acc2), LineNo, {nil, LineNo})};
 make_ar2([#riak_field_v1{name = Nm,
-			 type = {map, M}} | T], LineNo, Acc1, Acc2) ->
+                         type = {map, M}} | T], LineNo, Acc1, Acc2) ->
     {NewArg1, NewF1} = make_args_and_fields(M, LineNo),
     NewNm = make_string(binary_to_list(Nm), LineNo),
     NewF2 = make_tuple([NewNm, NewF1], LineNo),
@@ -591,7 +599,7 @@ make_fail_clause(LineNo) ->
 get_fn_name(Root, 1) when is_atom(Root) ->
     Root;
 get_fn_name(Root, FunNo) when is_atom(Root) andalso
-			      is_integer(FunNo) ->
+                              is_integer(FunNo) ->
     list_to_atom(atom_to_list(Root) ++ integer_to_list(FunNo)).
 
 -spec make_clause(ast(), guards(), expr(), pos_integer()) -> expr().
@@ -613,12 +621,15 @@ make_module_attr(ModName, LineNo) ->
 make_export_attr(LineNo) ->
     {{attribute, LineNo, export, [
                                   {validate_obj,    1},
-				  {add_column_info, 1},
+                                  {add_column_info, 1},
                                   {get_field_type,  1},
                                   {is_field_valid,  1},
                                   {extract,         2},
                                   {get_ddl,         0}
                                  ]}, LineNo + 1}.
+
+unzip_sorted(L) ->
+    lists:unzip(lists:sort(L)).
 
 -ifdef(TEST).
 -compile(export_all).
@@ -632,11 +643,11 @@ make_export_attr(LineNo) ->
 %% Helper fns
 %%
 
-make_ddl(#ddl_v1{table = Table,
-                 fields = Fields,
-                 partition_key = PK,
-                 local_key = LK
-                }) ->
+make_ddl(?DDL{table = Table,
+              fields = Fields,
+              partition_key = PK,
+              local_key = LK
+             }) ->
     make_ddl(Table, Fields, PK, LK).
 
 make_ddl(Table, Fields) when is_binary(Table) ->
@@ -647,10 +658,10 @@ make_ddl(Table, Fields, PK) when is_binary(Table) ->
 
 make_ddl(Table, Fields, #key_v1{} = PK, #key_v1{} = LK)
   when is_binary(Table) ->
-    #ddl_v1{table         = Table,
-            fields        = Fields,
-            partition_key = PK,
-            local_key     = LK}.
+    ?DDL{table         = Table,
+         fields        = Fields,
+         partition_key = PK,
+         local_key     = LK}.
 
 %%
 %% Unit Tests
@@ -664,11 +675,11 @@ simplest_valid_test() ->
 
 make_simplest_valid_ddl() ->
     make_ddl(<<"simplest_valid_test">>,
-	     [
-	      #riak_field_v1{name     = <<"yando">>,
-			     position = 1,
-			     type     = varchar}
-	     ]).
+             [
+              #riak_field_v1{name     = <<"yando">>,
+                             position = 1,
+                             type     = varchar}
+             ]).
 
 simple_valid_varchar_test() ->
     DDL = make_simple_valid_varchar_ddl(),
@@ -678,14 +689,14 @@ simple_valid_varchar_test() ->
 
 make_simple_valid_varchar_ddl() ->
     make_ddl(<<"simple_valid_varchar_test">>,
-	     [
-	      #riak_field_v1{name     = <<"yando">>,
-			     position = 1,
-			     type     = varchar},
-	      #riak_field_v1{name     = <<"erko">>,
-			     position = 2,
-			     type     = varchar}
-	     ]).
+             [
+              #riak_field_v1{name     = <<"yando">>,
+                             position = 1,
+                             type     = varchar},
+              #riak_field_v1{name     = <<"erko">>,
+                             position = 2,
+                             type     = varchar}
+             ]).
 
 simple_valid_sint64_test() ->
     DDL = make_simple_valid_sint64_ddl(),
@@ -1507,41 +1518,41 @@ complex_ddl_test() ->
     ?assertEqual(?VALID, Result).
 
 make_complex_ddl_ddl() ->
-    #ddl_v1{
+    ?DDL{
        table = <<"temperatures">>,
        fields = [
-		 #riak_field_v1{
-		    name     = <<"time">>,
-		    position = 1,
-		    type     = timestamp,
-		    optional = false},
-		 #riak_field_v1{
-		    name     = <<"user_id">>,
-		    position = 2,
-		    type     = varchar,
-		    optional = false}
-		],
+                 #riak_field_v1{
+                    name     = <<"time">>,
+                    position = 1,
+                    type     = timestamp,
+                    optional = false},
+                 #riak_field_v1{
+                    name     = <<"user_id">>,
+                    position = 2,
+                    type     = varchar,
+                    optional = false}
+                ],
        partition_key = #key_v1{ast = [
-				      #param_v1{name = [<<"time">>]},
-				      #hash_fn_v1{mod  = crypto,
-						  fn   = hash,
-						  %% list isn't a valid arg
-						  %% type output from the
-						  %% lexer/parser
-						  args = [
-							  sha512,
-							  true,
-							  1,
-							  1.0,
-							  <<"abc">>
-							 ]}
-				     ]},
+                                      #param_v1{name = [<<"time">>]},
+                                      #hash_fn_v1{mod  = crypto,
+                                                  fn   = hash,
+                                                  %% list isn't a valid arg
+                                                  %% type output from the
+                                                  %% lexer/parser
+                                                  args = [
+                                                          sha512,
+                                                          true,
+                                                          1,
+                                                          1.0,
+                                                          <<"abc">>
+                                                         ]}
+                                     ]},
        local_key = #key_v1{ast = [
-				  #hash_fn_v1{mod  = crypto,
-					      fn   = hash,
-					      args = [ripemd]},
-				  #param_v1{name = [<<"time">>]}
-				 ]}}.
+                                  #hash_fn_v1{mod  = crypto,
+                                              fn   = hash,
+                                              args = [ripemd]},
+                                  #param_v1{name = [<<"time">>]}
+                                 ]}}.
 
 %%
 %% Test the add column info functionality
@@ -1649,44 +1660,44 @@ timeseries_ddl_get_test() ->
 
 make_timeseries_ddl() ->
     Fields = [
-	      #riak_field_v1{name     = <<"geohash">>,
-			     position = 1,
-			     type     = varchar,
-			     optional = false},
-	      #riak_field_v1{name     = <<"user">>,
-			     position = 2,
-			     type     = varchar,
-			     optional = false},
-	      #riak_field_v1{name     = <<"time">>,
-			     position = 3,
-			     type     = timestamp,
-			     optional = false},
-	      #riak_field_v1{name     = <<"weather">>,
-			     position = 4,
-			     type     = varchar,
-			     optional = false},
-	      #riak_field_v1{name     = <<"temperature">>,
-			     position = 5,
-			     type     = varchar,
-			     optional = true}
-	     ],
+              #riak_field_v1{name     = <<"geohash">>,
+                             position = 1,
+                             type     = varchar,
+                             optional = false},
+              #riak_field_v1{name     = <<"user">>,
+                             position = 2,
+                             type     = varchar,
+                             optional = false},
+              #riak_field_v1{name     = <<"time">>,
+                             position = 3,
+                             type     = timestamp,
+                             optional = false},
+              #riak_field_v1{name     = <<"weather">>,
+                             position = 4,
+                             type     = varchar,
+                             optional = false},
+              #riak_field_v1{name     = <<"temperature">>,
+                             position = 5,
+                             type     = varchar,
+                             optional = true}
+             ],
     PK = #key_v1{ ast = [
-			 #hash_fn_v1{mod  = riak_ql_quanta,
-				     fn   = quantum,
-				     args = [
-					     #param_v1{name = [<<"time">>]},
-					     15,
-					     s
-					    ]}
-			]},
+                         #hash_fn_v1{mod  = riak_ql_quanta,
+                                     fn   = quantum,
+                                     args = [
+                                             #param_v1{name = [<<"time">>]},
+                                             15,
+                                             s
+                                            ]}
+                        ]},
     LK = #key_v1{ast = [
-			#param_v1{name = [<<"time">>]},
-			#param_v1{name = [<<"user">>]}]
-		},
-    _DDL = #ddl_v1{table         = <<"timeseries_filter_test">>,
-		   fields        = Fields,
-		   partition_key = PK,
-		   local_key     = LK
-		  }.
+                        #param_v1{name = [<<"time">>]},
+                        #param_v1{name = [<<"user">>]}]
+                },
+    _DDL = ?DDL{table         = <<"timeseries_filter_test">>,
+                fields        = Fields,
+                partition_key = PK,
+                local_key     = LK
+               }.
 
 -endif.

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -1,7 +1,7 @@
 %%% -*- mode: erlang -*-
 %%% @doc       Lexer for the riak Time Series Query Language.
 %%% @author    gguthrie@basho.com
-%%% @copyright (C) 2015 Basho
+%%% @copyright (C) 2015, 2016 Basho
 
 Definitions.
 
@@ -26,6 +26,7 @@ TIMESTAMP = (T|t)(I|i)(M|m)(E|e)(S|s)(T|t)(A|a)(M|m)(P|p)
 TRUE = (T|t)(R|r)(U|u)(E|e)
 VARCHAR = (V|v)(A|a)(R|r)(C|c)(H|h)(A|a)(R|r)
 WHERE = (W|w)(H|h)(E|e)(R|r)(E|e)
+WITH = (W|w)(I|i)(T|t)(H|h)
 
 CHARACTER_LITERAL = ('([^\']|(\'\'))*')
 
@@ -85,6 +86,7 @@ Rules.
 {TRUE} : {token, {true, list_to_binary(TokenChars)}}.
 {VARCHAR} : {token, {varchar, list_to_binary(TokenChars)}}.
 {WHERE} : {token, {where, list_to_binary(TokenChars)}}.
+{WITH} : {token, {with, list_to_binary(TokenChars)}}.
 
 {INTNUM}   : {token, {integer, list_to_integer(TokenChars)}}.
 

--- a/test/parser_create_table_tests.erl
+++ b/test/parser_create_table_tests.erl
@@ -25,10 +25,10 @@ create_timeseries_sql_test() ->
         " PRIMARY KEY ((geohash, user, quantum(time, 15, 'm')), geohash, user, time))",
     Toks = riak_ql_lexer:get_tokens(String),
     Got = case riak_ql_parser:parse(Toks) of
-              {ok, G} -> G;
+              {ok, DDL} -> DDL;
               _WC     -> wont_compile
           end,
-    Expected = #ddl_v1{
+    Expected = ?DDL{
                   table = <<"GeoCheckin">>,
                   fields = [
                             #riak_field_v1{
@@ -96,10 +96,10 @@ create_all_types_sql_test() ->
         " user, geohash, time))",
     Toks = riak_ql_lexer:get_tokens(String),
     Got = case riak_ql_parser:parse(Toks) of
-              {ok, G} -> G;
-              WC     -> WC
+              {ok, DDL} -> DDL;
+              WC -> WC
           end,
-    Expected = #ddl_v1{
+    Expected = ?DDL{
                   table = <<"GeoCheckin">>,
                   fields = [
                             #riak_field_v1{
@@ -251,7 +251,7 @@ create_table_white_space_test() ->
         "PRIMARY KEY "
         " ((family, series, quantum(time, 15, 's')), family, series, time))",
     ?assertMatch(
-       {ok, #ddl_v1{}},
+       {ok, ?DDL{}},
        riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def))
       ).
 
@@ -264,7 +264,7 @@ primary_key_white_space_test() ->
         "PRIMARY               \t  KEY "
         " ((family, series, quantum(time, 15, 's')), family, series, time))",
     ?assertMatch(
-       {ok, #ddl_v1{}},
+       {ok, ?DDL{}},
        riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def))
       ).
 
@@ -277,6 +277,34 @@ not_null_white_space_test() ->
         "PRIMARY KEY "
         " ((family, series, quantum(time, 15, 's')), family, series, time))",
     ?assertMatch(
-       {ok, #ddl_v1{}},
+       {ok, ?DDL{}},
+       riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def))
+      ).
+
+create_with_1_test() ->
+    Table_def =
+        "CREATE TABLE temperatures ("
+        "family VARCHAR NOT NULL, "
+        "series VARCHAR NOT NULL, "
+        "time TIMESTAMP NOT NULL, "
+        "PRIMARY KEY "
+        " ((family, series, quantum(time, 15, 's')), family, series, time))"
+        " with (a='2a')",
+    ?assertMatch(
+       {ok, ?DDL{properties = [{<<"a">>, <<"2a">>}]}},
+       riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def))
+      ).
+
+create_with_2_test() ->
+    Table_def =
+        "CREATE TABLE temperatures ("
+        "family VARCHAR NOT NULL, "
+        "series VARCHAR NOT NULL, "
+        "time TIMESTAMP NOT NULL, "
+        "PRIMARY KEY "
+        " ((family, series, quantum(time, 15, 's')), family, series, time))"
+        " with (a ='2a', c= 3)",
+    ?assertMatch(
+       {ok, ?DDL{properties = [{<<"a">>, <<"2a">>}, {<<"c">>, 3}]}},
        riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def))
       ).


### PR DESCRIPTION
RTS-865

Complementary PRs are https://github.com/basho/riak_kv/pull/1332 and https://github.com/basho/riak_core/pull/805.

This is an alternative (to https://github.com/basho/riak_ql/pull/96) way to implement setting table/bucket properties with `WITH` in the query string. It differs from #96 in that the properties proplist is now part of the ddl record, which becomes `#ddl_v2{}`.

The implications are twofold:
1. The supported version of the ddl record needs to be registered with core capabilities.
2. There is circularity arising from the properties field being in `#ddl_v2{}`: one of the properties of a table is `ddl`, which contains the entire AST of the table, which carries `properties` as a field, of which one property is `ddl`, and so on. Obviously, the circularity has to be broken at some point, and it's not immediately clear where exactly.

Requesting comments.
