### PR TITLE
RTS-877: Return a Human-Readable Error When Comparing Fields

### DIFF
--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -171,7 +171,7 @@ convert([#param_v1{name = Nm} | T], Obj, Mod, Acc) ->
 convert([Constant | T], Obj, Mod, Acc) ->
     convert(T, Obj, Mod, [Constant | Acc]).
 
-%% Convert an error emmitted from the :is_query_valid/3 function
+%% Convert an error emitted from the :is_query_valid/3 function
 %% and convert it into a user-friendly, text message binary.
 -spec syntax_error_to_msg(query_syntax_error()) ->
                                  Msg::binary().
@@ -205,7 +205,9 @@ syntax_error_to_msg2({subexpressions_not_supported, Field, Op}) ->
      " (~s ~s ...) are not supported.",
      [Field, Op]};
 syntax_error_to_msg2({unknown_column_type, Other}) ->
-    {"Unexpected select column type ~p.", [Other]}.
+    {"Unexpected select column type ~p.", [Other]};
+syntax_error_to_msg2({invalid_field_operation}) ->
+    {"Comparing or otherwise operating on two fields is not supported", []}.
 
 %% An atom with upper case chars gets printed as 'COUNT' so remove the
 %% quotes to make the error message more reable.
@@ -257,6 +259,9 @@ is_filters_field_valid(Mod, {Op, Field, {RHS_type, RHS_Val}}, Acc1) ->
         false ->
             [{unexpected_where_field, Field} | Acc1]
     end;
+%% the case where two fields are being operated on
+is_filters_field_valid(_Mod, {_Op, _Field1, _Field2}, Acc1) when is_binary(_Field1), is_binary(_Field2) ->
+    [{invalid_field_operation} | Acc1];
 %% the case where RHS is an expression on its own (LHS must still be a valid field)
 is_filters_field_valid(_Mod, {Op, Field, {_RHS_op, _RHS_lhs_bare_value, _RHS_rhs}}, Acc1) ->
     [{subexpressions_not_supported, Field, Op} | Acc1].


### PR DESCRIPTION
Return a nice, human-readable error if user tries to compare two column names instead of a mismatched stack trace in `riak_ql_ddl:is_filters_field_valid`
