### PR TITLE
RTS-901: Add riak_ql_ddl:get_version/0

### DIFF
--- a/include/riak_ql_ddl.hrl
+++ b/include/riak_ql_ddl.hrl
@@ -23,6 +23,7 @@
 -ifndef(RIAK_QL_DDL_HRL).
 -define(RIAK_QL_DDL_HRL, included).
 
+-define(RIAK_QL_DDL_VERSION, <<"1.2">>).
 -record(riak_field_v1, {
           name     = <<>>  :: binary(),
           position         :: undefined | pos_integer(),

--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -25,7 +25,8 @@
 
 %% this function can be used to work out which Module to use
 -export([
-         make_module_name/1, make_module_name/2
+         make_module_name/1, make_module_name/2,
+         get_version/0
         ]).
 
 -type ddl() :: #ddl_v1{}.
@@ -64,6 +65,10 @@
 
 -define(CANBEBLANK,  true).
 -define(CANTBEBLANK, false).
+
+-spec get_version() -> binary().
+get_version() ->
+    ?RIAK_QL_DDL_VERSION.
 
 -spec make_module_name(Table::binary()) ->
                               module().


### PR DESCRIPTION
Primarily this is used to report the SQL version to `riak_shell` (https://github.com/basho/riak_shell/pull/8), but might be useful elsewhere, too.
