### PR TITLE
RTS-904: Allow select to only use a single table

### DIFF
--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -133,8 +133,8 @@ StatementWithoutSemicolon -> Insert : '$1'.
 Query -> Select limit integer : add_limit('$1', '$2', '$3').
 Query -> Select               : '$1'.
 
-Select -> select Fields from Buckets Where : make_select('$1', '$2', '$3', '$4', '$5').
-Select -> select Fields from Buckets       : make_select('$1', '$2', '$3', '$4').
+Select -> select Fields from Bucket Where : make_select('$1', '$2', '$3', '$4', '$5').
+Select -> select Fields from Bucket       : make_select('$1', '$2', '$3', '$4').
 
 %% 20.9 DESCRIBE STATEMENT
 Describe -> describe Bucket : make_describe('$2').

--- a/test/parser_select_tests.erl
+++ b/test/parser_select_tests.erl
@@ -93,14 +93,7 @@ select_nested_quotes_sql_test() ->
        ]).
 
 select_from_lists_sql_test() ->
-    ?sql_comp_assert_match(
-       "select * from events, errors", select,
-       [{fields, [
-                  {identifier, [<<"*">>]}
-                 ]},
-        {tables, {list, [<<"events">>, <<"errors">>]}},
-        {where, []}
-       ]).
+    ?sql_comp_fail("select * from events, errors").
 
 select_fields_from_lists_sql_test() ->
     ?sql_comp_assert_match(


### PR DESCRIPTION
Previously we allowed the construct `select * from foo, baz` however currently riak_ts only supports a single table.  This was making riak_kv unhappy.
