### PR TITLE
Use a macro for the param record name

### DIFF
--- a/include/riak_ql_ddl.hrl
+++ b/include/riak_ql_ddl.hrl
@@ -36,22 +36,22 @@
          }).
 
 
--define(PARAM, #param_v1).
--define(PARAM_RECORD_NAME, param_v1).
--define(PARAM_RECORD_VERSION, 1).
--record(?PARAM_RECORD_NAME, {
+-define(SQL_PARAM, #param_v1).
+-define(SQL_PARAM_RECORD_NAME, param_v1).
+-define(SQL_PARAM_RECORD_VERSION, 1).
+-record(?SQL_PARAM_RECORD_NAME, {
           name = [<<>>] :: [binary()]
          }).
 
 -record(hash_fn_v1, {
           mod       :: atom(),
           fn        :: atom(),
-          args = [] :: [?PARAM{} | any()],
+          args = [] :: [?SQL_PARAM{} | any()],
           type      :: riak_ql_ddl:simple_field_type()
          }).
 
 -record(key_v1, {
-          ast = [] :: [#hash_fn_v1{} | ?PARAM{}]
+          ast = [] :: [#hash_fn_v1{} | ?SQL_PARAM{}]
          }).
 
 -record(ddl_v1, {

--- a/include/riak_ql_ddl.hrl
+++ b/include/riak_ql_ddl.hrl
@@ -36,19 +36,22 @@
          }).
 
 
--record(param_v1, {
+-define(PARAM, #param_v1).
+-define(PARAM_RECORD_NAME, param_v1).
+-define(PARAM_RECORD_VERSION, 1).
+-record(?PARAM_RECORD_NAME, {
           name = [<<>>] :: [binary()]
          }).
 
 -record(hash_fn_v1, {
           mod       :: atom(),
           fn        :: atom(),
-          args = [] :: [#param_v1{} | any()],
+          args = [] :: [?PARAM{} | any()],
           type      :: riak_ql_ddl:simple_field_type()
          }).
 
 -record(key_v1, {
-          ast = [] :: [#hash_fn_v1{} | #param_v1{}]
+          ast = [] :: [#hash_fn_v1{} | ?PARAM{}]
          }).
 
 -record(ddl_v1, {
@@ -57,7 +60,6 @@
           partition_key      :: #key_v1{} | none,
           local_key          :: #key_v1{}
          }).
-
 -define(DDL, #ddl_v1).
 -define(DDL_RECORD_NAME, ddl_v1).
 -define(DDL_RECORD_VERSION, 1).

--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -176,7 +176,7 @@ mk_k([#hash_fn_v1{mod = Md,
     A2 = extract(Args, Vals, []),
     V  = erlang:apply(Md, Fn, A2),
     mk_k(T1, Vals, Mod, [{Ty, V} | Acc]);
-mk_k([#param_v1{name = [Nm]} | T1], Vals, Mod, Acc) ->
+mk_k([?PARAM{name = [Nm]} | T1], Vals, Mod, Acc) ->
     {Nm, V} = lists:keyfind(Nm, 1, Vals),
     Ty = Mod:get_field_type([Nm]),
     mk_k(T1, Vals, Mod, [{Ty, V} | Acc]).
@@ -184,16 +184,16 @@ mk_k([#param_v1{name = [Nm]} | T1], Vals, Mod, Acc) ->
 -spec extract(list(), [{any(), any()}], [any()]) -> any().
 extract([], _Vals, Acc) ->
     lists:reverse(Acc);
-extract([#param_v1{name = [Nm]} | T], Vals, Acc) ->
+extract([?PARAM{name = [Nm]} | T], Vals, Acc) ->
     {Nm, Val} = lists:keyfind(Nm, 1, Vals),
     extract(T, Vals, [Val | Acc]);
 extract([Constant | T], Vals, Acc) ->
     extract(T, Vals, [Constant | Acc]).
 
--spec build([#param_v1{}], tuple(), atom(), any()) -> list().
+-spec build([?PARAM{}], tuple(), atom(), any()) -> list().
 build([], _Obj, _Mod, A) ->
     lists:reverse(A);
-build([#param_v1{name = Nm} | T], Obj, Mod, A) ->
+build([?PARAM{name = Nm} | T], Obj, Mod, A) ->
     Val = Mod:extract(Obj, Nm),
     Type = Mod:get_field_type(Nm),
     build(T, Obj, Mod, [{Type, Val} | A]);
@@ -205,10 +205,10 @@ build([#hash_fn_v1{mod  = Md,
     Val = erlang:apply(Md, Fn, A2),
     build(T, Obj, Mod, [{Ty, Val} | A]).
 
--spec convert([#param_v1{}], tuple(), atom(), [any()]) -> any().
+-spec convert([?PARAM{}], tuple(), atom(), [any()]) -> any().
 convert([], _Obj, _Mod, Acc) ->
     lists:reverse(Acc);
-convert([#param_v1{name = Nm} | T], Obj, Mod, Acc) ->
+convert([?PARAM{name = Nm} | T], Obj, Mod, Acc) ->
     Val = Mod:extract(Obj, Nm),
     convert(T, Obj, Mod, [Val | Acc]);
 convert([Constant | T], Obj, Mod, Acc) ->
@@ -604,7 +604,7 @@ make_ddl(Table, Fields, #key_v1{} = PK, #key_v1{} = LK)
 simplest_partition_key_test() ->
     Name = <<"yando">>,
     PK = #key_v1{ast = [
-                        #param_v1{name = [Name]}
+                        ?PARAM{name = [Name]}
                        ]},
     DDL = make_ddl(<<"simplest_partition_key_test">>,
                    [
@@ -622,8 +622,8 @@ simple_partition_key_test() ->
     Name1 = <<"yando">>,
     Name2 = <<"buckle">>,
     PK = #key_v1{ast = [
-                        #param_v1{name = [Name1]},
-                        #param_v1{name = [Name2]}
+                        ?PARAM{name = [Name1]},
+                        ?PARAM{name = [Name2]}
                        ]},
     DDL = make_ddl(<<"simple_partition_key_test">>,
                    [
@@ -647,11 +647,11 @@ function_partition_key_test() ->
     Name1 = <<"yando">>,
     Name2 = <<"buckle">>,
     PK = #key_v1{ast = [
-                        #param_v1{name = [Name1]},
+                        ?PARAM{name = [Name1]},
                         #hash_fn_v1{mod  = ?MODULE,
                                     fn   = mock_partition_fn,
                                     args = [
-                                            #param_v1{name = [Name2]},
+                                            ?PARAM{name = [Name2]},
                                             15,
                                             m
                                            ],
@@ -686,10 +686,10 @@ function_partition_key_test() ->
 local_key_test() ->
     Name = <<"yando">>,
     PK = #key_v1{ast = [
-                        #param_v1{name = [Name]}
+                        ?PARAM{name = [Name]}
                        ]},
     LK = #key_v1{ast = [
-                        #param_v1{name = [Name]}
+                        ?PARAM{name = [Name]}
                        ]},
     DDL = make_ddl(<<"simplest_key_key_test">>,
                    [
@@ -710,8 +710,8 @@ local_key_test() ->
 
 make_plain_key_test() ->
     Key = #key_v1{ast = [
-                         #param_v1{name = [<<"user">>]},
-                         #param_v1{name = [<<"time">>]}
+                         ?PARAM{name = [<<"user">>]},
+                         ?PARAM{name = [<<"time">>]}
                         ]},
     DDL = make_ddl(<<"make_plain_key_test">>,
                    [
@@ -736,11 +736,11 @@ make_plain_key_test() ->
 
 make_functional_key_test() ->
     Key = #key_v1{ast = [
-                         #param_v1{name = [<<"user">>]},
+                         ?PARAM{name = [<<"user">>]},
                          #hash_fn_v1{mod  = ?MODULE,
                                      fn   = mock_partition_fn,
                                      args = [
-                                             #param_v1{name = [<<"time">>]},
+                                             ?PARAM{name = [<<"time">>]},
                                              15,
                                              m
                                             ],
@@ -931,14 +931,14 @@ timeseries_filter_test() ->
                         #hash_fn_v1{mod  = riak_ql_quanta,
                                     fn   = quantum,
                                     args = [
-                                            #param_v1{name = [<<"time">>]},
+                                            ?PARAM{name = [<<"time">>]},
                                             15,
                                             s
                                            ]}
                        ]},
     LK = #key_v1{ast = [
-                        #param_v1{name = [<<"time">>]},
-                        #param_v1{name = [<<"user">>]}]
+                        ?PARAM{name = [<<"time">>]},
+                        ?PARAM{name = [<<"user">>]}]
                 },
     DDL = ?DDL{table         = <<"timeseries_filter_test">>,
                fields        = Fields,

--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -176,7 +176,7 @@ mk_k([#hash_fn_v1{mod = Md,
     A2 = extract(Args, Vals, []),
     V  = erlang:apply(Md, Fn, A2),
     mk_k(T1, Vals, Mod, [{Ty, V} | Acc]);
-mk_k([?PARAM{name = [Nm]} | T1], Vals, Mod, Acc) ->
+mk_k([?SQL_PARAM{name = [Nm]} | T1], Vals, Mod, Acc) ->
     {Nm, V} = lists:keyfind(Nm, 1, Vals),
     Ty = Mod:get_field_type([Nm]),
     mk_k(T1, Vals, Mod, [{Ty, V} | Acc]).
@@ -184,16 +184,16 @@ mk_k([?PARAM{name = [Nm]} | T1], Vals, Mod, Acc) ->
 -spec extract(list(), [{any(), any()}], [any()]) -> any().
 extract([], _Vals, Acc) ->
     lists:reverse(Acc);
-extract([?PARAM{name = [Nm]} | T], Vals, Acc) ->
+extract([?SQL_PARAM{name = [Nm]} | T], Vals, Acc) ->
     {Nm, Val} = lists:keyfind(Nm, 1, Vals),
     extract(T, Vals, [Val | Acc]);
 extract([Constant | T], Vals, Acc) ->
     extract(T, Vals, [Constant | Acc]).
 
--spec build([?PARAM{}], tuple(), atom(), any()) -> list().
+-spec build([?SQL_PARAM{}], tuple(), atom(), any()) -> list().
 build([], _Obj, _Mod, A) ->
     lists:reverse(A);
-build([?PARAM{name = Nm} | T], Obj, Mod, A) ->
+build([?SQL_PARAM{name = Nm} | T], Obj, Mod, A) ->
     Val = Mod:extract(Obj, Nm),
     Type = Mod:get_field_type(Nm),
     build(T, Obj, Mod, [{Type, Val} | A]);
@@ -205,10 +205,10 @@ build([#hash_fn_v1{mod  = Md,
     Val = erlang:apply(Md, Fn, A2),
     build(T, Obj, Mod, [{Ty, Val} | A]).
 
--spec convert([?PARAM{}], tuple(), atom(), [any()]) -> any().
+-spec convert([?SQL_PARAM{}], tuple(), atom(), [any()]) -> any().
 convert([], _Obj, _Mod, Acc) ->
     lists:reverse(Acc);
-convert([?PARAM{name = Nm} | T], Obj, Mod, Acc) ->
+convert([?SQL_PARAM{name = Nm} | T], Obj, Mod, Acc) ->
     Val = Mod:extract(Obj, Nm),
     convert(T, Obj, Mod, [Val | Acc]);
 convert([Constant | T], Obj, Mod, Acc) ->
@@ -604,7 +604,7 @@ make_ddl(Table, Fields, #key_v1{} = PK, #key_v1{} = LK)
 simplest_partition_key_test() ->
     Name = <<"yando">>,
     PK = #key_v1{ast = [
-                        ?PARAM{name = [Name]}
+                        ?SQL_PARAM{name = [Name]}
                        ]},
     DDL = make_ddl(<<"simplest_partition_key_test">>,
                    [
@@ -622,8 +622,8 @@ simple_partition_key_test() ->
     Name1 = <<"yando">>,
     Name2 = <<"buckle">>,
     PK = #key_v1{ast = [
-                        ?PARAM{name = [Name1]},
-                        ?PARAM{name = [Name2]}
+                        ?SQL_PARAM{name = [Name1]},
+                        ?SQL_PARAM{name = [Name2]}
                        ]},
     DDL = make_ddl(<<"simple_partition_key_test">>,
                    [
@@ -647,11 +647,11 @@ function_partition_key_test() ->
     Name1 = <<"yando">>,
     Name2 = <<"buckle">>,
     PK = #key_v1{ast = [
-                        ?PARAM{name = [Name1]},
+                        ?SQL_PARAM{name = [Name1]},
                         #hash_fn_v1{mod  = ?MODULE,
                                     fn   = mock_partition_fn,
                                     args = [
-                                            ?PARAM{name = [Name2]},
+                                            ?SQL_PARAM{name = [Name2]},
                                             15,
                                             m
                                            ],
@@ -686,10 +686,10 @@ function_partition_key_test() ->
 local_key_test() ->
     Name = <<"yando">>,
     PK = #key_v1{ast = [
-                        ?PARAM{name = [Name]}
+                        ?SQL_PARAM{name = [Name]}
                        ]},
     LK = #key_v1{ast = [
-                        ?PARAM{name = [Name]}
+                        ?SQL_PARAM{name = [Name]}
                        ]},
     DDL = make_ddl(<<"simplest_key_key_test">>,
                    [
@@ -710,8 +710,8 @@ local_key_test() ->
 
 make_plain_key_test() ->
     Key = #key_v1{ast = [
-                         ?PARAM{name = [<<"user">>]},
-                         ?PARAM{name = [<<"time">>]}
+                         ?SQL_PARAM{name = [<<"user">>]},
+                         ?SQL_PARAM{name = [<<"time">>]}
                         ]},
     DDL = make_ddl(<<"make_plain_key_test">>,
                    [
@@ -736,11 +736,11 @@ make_plain_key_test() ->
 
 make_functional_key_test() ->
     Key = #key_v1{ast = [
-                         ?PARAM{name = [<<"user">>]},
+                         ?SQL_PARAM{name = [<<"user">>]},
                          #hash_fn_v1{mod  = ?MODULE,
                                      fn   = mock_partition_fn,
                                      args = [
-                                             ?PARAM{name = [<<"time">>]},
+                                             ?SQL_PARAM{name = [<<"time">>]},
                                              15,
                                              m
                                             ],
@@ -931,14 +931,14 @@ timeseries_filter_test() ->
                         #hash_fn_v1{mod  = riak_ql_quanta,
                                     fn   = quantum,
                                     args = [
-                                            ?PARAM{name = [<<"time">>]},
+                                            ?SQL_PARAM{name = [<<"time">>]},
                                             15,
                                             s
                                            ]}
                        ]},
     LK = #key_v1{ast = [
-                        ?PARAM{name = [<<"time">>]},
-                        ?PARAM{name = [<<"user">>]}]
+                        ?SQL_PARAM{name = [<<"time">>]},
+                        ?SQL_PARAM{name = [<<"user">>]}]
                 },
     DDL = ?DDL{table         = <<"timeseries_filter_test">>,
                fields        = Fields,

--- a/src/riak_ql_ddl_compiler.erl
+++ b/src/riak_ql_ddl_compiler.erl
@@ -221,14 +221,14 @@ canonical_ast_fmt(#hash_fn_v1{mod  = Mod,
     Args2 = [canonical_arg_fmt_v1(X) || X <- Args],
     string:join([atom_to_list(Mod), atom_to_list(Fn)]
                         ++ Args2 ++ [atom_to_list(Type)], " ");
-canonical_ast_fmt(#param_v1{name = [Nm]}) ->
+canonical_ast_fmt(?PARAM{name = [Nm]}) ->
     binary_to_list(Nm).
 
 canonical_arg_fmt_v1(B) when is_binary(B)    -> binary_to_list(B);
 canonical_arg_fmt_v1(F) when is_float(F)     -> float_to_list(F);
 canonical_arg_fmt_v1(N) when is_integer(N)   -> integer_to_list(N);
 canonical_arg_fmt_v1(A) when is_atom(A)      -> atom_to_list(A);
-canonical_arg_fmt_v1(#param_v1{name = [Nm]}) -> binary_to_list(Nm).
+canonical_arg_fmt_v1(?PARAM{name = [Nm]}) -> binary_to_list(Nm).
 
 %% the funny shape of this function is because it used to handle maps
 %% which needed recursion - not refactoring because it will be merled
@@ -326,10 +326,10 @@ expand_ast(AST, LineNo) when is_list(AST) ->
     Fields = [expand_a2(X, LineNo) || X <- AST],
     make_conses(lists:reverse(Fields), LineNo, {nil, LineNo}).
 
-expand_a2(#param_v1{name = Nm}, LineNo) ->
+expand_a2(?PARAM{name = Nm}, LineNo) ->
     Bins = [make_binary(X, LineNo) || X <- Nm],
     Conses = make_conses(Bins, LineNo, {nil, LineNo}),
-    make_tuple([make_atom(param_v1, LineNo) | [Conses]], LineNo);
+    make_tuple([make_atom(?PARAM_RECORD_NAME, LineNo) | [Conses]], LineNo);
 expand_a2(#hash_fn_v1{mod  = Mod,
                       fn   = Fn,
                       args = Args,
@@ -353,7 +353,7 @@ expand_args(Args, LineNo) ->
 
 %% this first clause jumps out to a different expansion tree
 %% to expand the parameter in the fuction args
-expand_args2(Arg, LineNo) when is_record(Arg, param_v1) ->
+expand_args2(Arg, LineNo) when is_record(Arg, ?PARAM_RECORD_NAME) ->
     expand_a2(Arg, LineNo);
 expand_args2(Arg, LineNo) when is_binary(Arg) ->
     make_binary(Arg, LineNo);
@@ -1100,7 +1100,7 @@ make_complex_ddl_ddl() ->
                     optional = false}
                 ],
        partition_key = #key_v1{ast = [
-                                      #param_v1{name = [<<"time">>]},
+                                      ?PARAM{name = [<<"time">>]},
                                       #hash_fn_v1{mod  = crypto,
                                                   fn   = hash,
                                                   %% list isn't a valid arg
@@ -1118,7 +1118,7 @@ make_complex_ddl_ddl() ->
                                   #hash_fn_v1{mod  = crypto,
                                               fn   = hash,
                                               args = [ripemd]},
-                                  #param_v1{name = [<<"time">>]}
+                                  ?PARAM{name = [<<"time">>]}
                                  ]}}.
 
 %%
@@ -1194,20 +1194,20 @@ make_timeseries_ddl() ->
                              optional = true}
              ],
     PK = #key_v1{ ast = [
-                        #param_v1{name = [<<"time">>]},
-                        #param_v1{name = [<<"user">>]},
+                        ?PARAM{name = [<<"time">>]},
+                        ?PARAM{name = [<<"user">>]},
                         #hash_fn_v1{mod  = riak_ql_quanta,
                                      fn   = quantum,
                                      args = [
-                                             #param_v1{name = [<<"time">>]},
+                                             ?PARAM{name = [<<"time">>]},
                                              15,
                                              s
                                             ],
                                    type = timestamp}
                         ]},
     LK = #key_v1{ast = [
-                        #param_v1{name = [<<"time">>]},
-                        #param_v1{name = [<<"user">>]}]
+                        ?PARAM{name = [<<"time">>]},
+                        ?PARAM{name = [<<"user">>]}]
                 },
     _DDL = ?DDL{table         = <<"timeseries_filter_test">>,
                 fields        = Fields,

--- a/src/riak_ql_ddl_compiler.erl
+++ b/src/riak_ql_ddl_compiler.erl
@@ -221,14 +221,14 @@ canonical_ast_fmt(#hash_fn_v1{mod  = Mod,
     Args2 = [canonical_arg_fmt_v1(X) || X <- Args],
     string:join([atom_to_list(Mod), atom_to_list(Fn)]
                         ++ Args2 ++ [atom_to_list(Type)], " ");
-canonical_ast_fmt(?PARAM{name = [Nm]}) ->
+canonical_ast_fmt(?SQL_PARAM{name = [Nm]}) ->
     binary_to_list(Nm).
 
 canonical_arg_fmt_v1(B) when is_binary(B)    -> binary_to_list(B);
 canonical_arg_fmt_v1(F) when is_float(F)     -> float_to_list(F);
 canonical_arg_fmt_v1(N) when is_integer(N)   -> integer_to_list(N);
 canonical_arg_fmt_v1(A) when is_atom(A)      -> atom_to_list(A);
-canonical_arg_fmt_v1(?PARAM{name = [Nm]}) -> binary_to_list(Nm).
+canonical_arg_fmt_v1(?SQL_PARAM{name = [Nm]}) -> binary_to_list(Nm).
 
 %% the funny shape of this function is because it used to handle maps
 %% which needed recursion - not refactoring because it will be merled
@@ -326,10 +326,10 @@ expand_ast(AST, LineNo) when is_list(AST) ->
     Fields = [expand_a2(X, LineNo) || X <- AST],
     make_conses(lists:reverse(Fields), LineNo, {nil, LineNo}).
 
-expand_a2(?PARAM{name = Nm}, LineNo) ->
+expand_a2(?SQL_PARAM{name = Nm}, LineNo) ->
     Bins = [make_binary(X, LineNo) || X <- Nm],
     Conses = make_conses(Bins, LineNo, {nil, LineNo}),
-    make_tuple([make_atom(?PARAM_RECORD_NAME, LineNo) | [Conses]], LineNo);
+    make_tuple([make_atom(?SQL_PARAM_RECORD_NAME, LineNo) | [Conses]], LineNo);
 expand_a2(#hash_fn_v1{mod  = Mod,
                       fn   = Fn,
                       args = Args,
@@ -353,7 +353,7 @@ expand_args(Args, LineNo) ->
 
 %% this first clause jumps out to a different expansion tree
 %% to expand the parameter in the fuction args
-expand_args2(Arg, LineNo) when is_record(Arg, ?PARAM_RECORD_NAME) ->
+expand_args2(Arg, LineNo) when is_record(Arg, ?SQL_PARAM_RECORD_NAME) ->
     expand_a2(Arg, LineNo);
 expand_args2(Arg, LineNo) when is_binary(Arg) ->
     make_binary(Arg, LineNo);
@@ -1100,7 +1100,7 @@ make_complex_ddl_ddl() ->
                     optional = false}
                 ],
        partition_key = #key_v1{ast = [
-                                      ?PARAM{name = [<<"time">>]},
+                                      ?SQL_PARAM{name = [<<"time">>]},
                                       #hash_fn_v1{mod  = crypto,
                                                   fn   = hash,
                                                   %% list isn't a valid arg
@@ -1118,7 +1118,7 @@ make_complex_ddl_ddl() ->
                                   #hash_fn_v1{mod  = crypto,
                                               fn   = hash,
                                               args = [ripemd]},
-                                  ?PARAM{name = [<<"time">>]}
+                                  ?SQL_PARAM{name = [<<"time">>]}
                                  ]}}.
 
 %%
@@ -1194,20 +1194,20 @@ make_timeseries_ddl() ->
                              optional = true}
              ],
     PK = #key_v1{ ast = [
-                        ?PARAM{name = [<<"time">>]},
-                        ?PARAM{name = [<<"user">>]},
+                        ?SQL_PARAM{name = [<<"time">>]},
+                        ?SQL_PARAM{name = [<<"user">>]},
                         #hash_fn_v1{mod  = riak_ql_quanta,
                                      fn   = quantum,
                                      args = [
-                                             ?PARAM{name = [<<"time">>]},
+                                             ?SQL_PARAM{name = [<<"time">>]},
                                              15,
                                              s
                                             ],
                                    type = timestamp}
                         ]},
     LK = #key_v1{ast = [
-                        ?PARAM{name = [<<"time">>]},
-                        ?PARAM{name = [<<"user">>]}]
+                        ?SQL_PARAM{name = [<<"time">>]},
+                        ?SQL_PARAM{name = [<<"user">>]}]
                 },
     _DDL = ?DDL{table         = <<"timeseries_filter_test">>,
                 fields        = Fields,

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -779,7 +779,7 @@ extract_key_field_list({list,
                        Extracted) ->
     [Modfun | extract_key_field_list({list, Rest}, Extracted)];
 extract_key_field_list({list, [Field | Rest]}, Extracted) ->
-    [?PARAM{name = [Field]} |
+    [?SQL_PARAM{name = [Field]} |
      extract_key_field_list({list, Rest}, Extracted)].
 
 make_table_definition(TableName, Contents) ->
@@ -815,7 +815,7 @@ make_modfun(quantum, {list, Args}) ->
     {modfun, #hash_fn_v1{
                 mod  = riak_ql_quanta,
                 fn   = quantum,
-                args = [?PARAM{name = [Param]}, Quantity, binary_to_existing_atom(Unit, utf8)],
+                args = [?SQL_PARAM{name = [Param]}, Quantity, binary_to_existing_atom(Unit, utf8)],
                 type = timestamp
                }}.
 
@@ -877,7 +877,7 @@ assert_keys_present(_GoodDDL) ->
 %% @doc Ensure all fields appearing in PRIMARY KEY are not null.
 assert_primary_key_fields_non_null(?DDL{local_key = #key_v1{ast = LK},
                                         fields = Fields}) ->
-    PKFieldNames = [N || ?PARAM{name = [N]} <- LK],
+    PKFieldNames = [N || ?SQL_PARAM{name = [N]} <- LK],
     OnlyPKFields = [F || #riak_field_v1{name = N} = F <- Fields,
                          lists:member(N, PKFieldNames)],
     NonNullFields =
@@ -910,7 +910,7 @@ assert_primary_and_local_keys_match(?DDL{partition_key = #key_v1{ast = Primary},
     end.
 
 assert_unique_fields_in_pk(?DDL{local_key = #key_v1{ast = LK}}) ->
-    Fields = [N || ?PARAM{name = [N]} <- LK],
+    Fields = [N || ?SQL_PARAM{name = [N]} <- LK],
     case length(Fields) == length(lists:usort(Fields)) of
         true ->
             ok;
@@ -995,9 +995,9 @@ is_field(Field, Fields) ->
     (lists:keyfind(name_of(Field), 2, Fields) /= false).
 
 %%
-name_of(?PARAM{ name = [N] }) ->
+name_of(?SQL_PARAM{ name = [N] }) ->
     N;
-name_of(#hash_fn_v1{ args = [?PARAM{ name = [N] }|_] }) ->
+name_of(#hash_fn_v1{ args = [?SQL_PARAM{ name = [N] }|_] }) ->
     N.
 
 which_duplicate(FF) ->
@@ -1013,9 +1013,9 @@ which_duplicate([_|T], Acc) ->
 
 %% Pull the name out of the appropriate record
 query_field_name(#hash_fn_v1{args = Args}) ->
-    Param = lists:keyfind(?PARAM_RECORD_NAME, 1, Args),
+    Param = lists:keyfind(?SQL_PARAM_RECORD_NAME, 1, Args),
     query_field_name(Param);
-query_field_name(?PARAM{name = Field}) ->
+query_field_name(?SQL_PARAM{name = Field}) ->
     Field.
 
 -spec return_error_flat(string()) -> no_return().

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -779,7 +779,7 @@ extract_key_field_list({list,
                        Extracted) ->
     [Modfun | extract_key_field_list({list, Rest}, Extracted)];
 extract_key_field_list({list, [Field | Rest]}, Extracted) ->
-    [#param_v1{name = [Field]} |
+    [?PARAM{name = [Field]} |
      extract_key_field_list({list, Rest}, Extracted)].
 
 make_table_definition(TableName, Contents) ->
@@ -815,7 +815,7 @@ make_modfun(quantum, {list, Args}) ->
     {modfun, #hash_fn_v1{
                 mod  = riak_ql_quanta,
                 fn   = quantum,
-                args = [#param_v1{name = [Param]}, Quantity, binary_to_existing_atom(Unit, utf8)],
+                args = [?PARAM{name = [Param]}, Quantity, binary_to_existing_atom(Unit, utf8)],
                 type = timestamp
                }}.
 
@@ -877,7 +877,7 @@ assert_keys_present(_GoodDDL) ->
 %% @doc Ensure all fields appearing in PRIMARY KEY are not null.
 assert_primary_key_fields_non_null(?DDL{local_key = #key_v1{ast = LK},
                                         fields = Fields}) ->
-    PKFieldNames = [N || #param_v1{name = [N]} <- LK],
+    PKFieldNames = [N || ?PARAM{name = [N]} <- LK],
     OnlyPKFields = [F || #riak_field_v1{name = N} = F <- Fields,
                          lists:member(N, PKFieldNames)],
     NonNullFields =
@@ -910,7 +910,7 @@ assert_primary_and_local_keys_match(?DDL{partition_key = #key_v1{ast = Primary},
     end.
 
 assert_unique_fields_in_pk(?DDL{local_key = #key_v1{ast = LK}}) ->
-    Fields = [N || #param_v1{name = [N]} <- LK],
+    Fields = [N || ?PARAM{name = [N]} <- LK],
     case length(Fields) == length(lists:usort(Fields)) of
         true ->
             ok;
@@ -995,9 +995,9 @@ is_field(Field, Fields) ->
     (lists:keyfind(name_of(Field), 2, Fields) /= false).
 
 %%
-name_of(#param_v1{ name = [N] }) ->
+name_of(?PARAM{ name = [N] }) ->
     N;
-name_of(#hash_fn_v1{ args = [#param_v1{ name = [N] }|_] }) ->
+name_of(#hash_fn_v1{ args = [?PARAM{ name = [N] }|_] }) ->
     N.
 
 which_duplicate(FF) ->
@@ -1013,9 +1013,9 @@ which_duplicate([_|T], Acc) ->
 
 %% Pull the name out of the appropriate record
 query_field_name(#hash_fn_v1{args = Args}) ->
-    Param = lists:keyfind(param_v1, 1, Args),
+    Param = lists:keyfind(?PARAM_RECORD_NAME, 1, Args),
     query_field_name(Param);
-query_field_name(#param_v1{name = Field}) ->
+query_field_name(?PARAM{name = Field}) ->
     Field.
 
 -spec return_error_flat(string()) -> no_return().

--- a/src/riak_ql_to_string.erl
+++ b/src/riak_ql_to_string.erl
@@ -118,19 +118,19 @@ make_f2([#riak_field_v1{name    = Nm,
     make_f2(T, [NewAcc | Acc]).
 
 pk_to_sql(#key_v1{ast = [Fam, Series, TS]}) ->
-    string:join([binary_to_list(extract(X#param_v1.name)) || X <- [Fam, Series]] ++ [make_q(TS)], ", ").
+    string:join([binary_to_list(extract(X?PARAM.name)) || X <- [Fam, Series]] ++ [make_q(TS)], ", ").
 
 make_q(#hash_fn_v1{mod  = riak_ql_quanta,
                    fn   = quantum,
                    args = Args,
                    type = timestamp}) ->
-              [#param_v1{name = [Nm]}, No, Unit] = Args,
+              [?PARAM{name = [Nm]}, No, Unit] = Args,
     _Q = "quantum(" ++ string:join([binary_to_list(Nm), integer_to_list(No), "'" ++ atom_to_list(Unit) ++ "'"], ", ") ++ ")".
 
 extract([X]) -> X.
 
 lk_to_sql(LK) ->
-    string:join([binary_to_list(extract(X#param_v1.name)) || X <- LK#key_v1.ast], ", ").
+    string:join([binary_to_list(extract(X?PARAM.name)) || X <- LK#key_v1.ast], ", ").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/riak_ql_to_string.erl
+++ b/src/riak_ql_to_string.erl
@@ -118,19 +118,19 @@ make_f2([#riak_field_v1{name    = Nm,
     make_f2(T, [NewAcc | Acc]).
 
 pk_to_sql(#key_v1{ast = [Fam, Series, TS]}) ->
-    string:join([binary_to_list(extract(X?PARAM.name)) || X <- [Fam, Series]] ++ [make_q(TS)], ", ").
+    string:join([binary_to_list(extract(X?SQL_PARAM.name)) || X <- [Fam, Series]] ++ [make_q(TS)], ", ").
 
 make_q(#hash_fn_v1{mod  = riak_ql_quanta,
                    fn   = quantum,
                    args = Args,
                    type = timestamp}) ->
-              [?PARAM{name = [Nm]}, No, Unit] = Args,
+              [?SQL_PARAM{name = [Nm]}, No, Unit] = Args,
     _Q = "quantum(" ++ string:join([binary_to_list(Nm), integer_to_list(No), "'" ++ atom_to_list(Unit) ++ "'"], ", ") ++ ")".
 
 extract([X]) -> X.
 
 lk_to_sql(LK) ->
-    string:join([binary_to_list(extract(X?PARAM.name)) || X <- LK#key_v1.ast], ", ").
+    string:join([binary_to_list(extract(X?SQL_PARAM.name)) || X <- LK#key_v1.ast], ", ").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/test/parser_create_table_tests.erl
+++ b/test/parser_create_table_tests.erl
@@ -78,20 +78,20 @@ create_timeseries_sql_test() ->
                            ],
                   partition_key = #key_v1{
                                      ast = [
-                                            ?PARAM{name = [<<"geohash">>]},
-                                            ?PARAM{name = [<<"user">>]},
+                                            ?SQL_PARAM{name = [<<"geohash">>]},
+                                            ?SQL_PARAM{name = [<<"user">>]},
                                             #hash_fn_v1{mod  = riak_ql_quanta,
                                                         fn   = quantum,
                                                         args = [
-                                                                ?PARAM{name = [<<"time">>]}, 15, m
+                                                                ?SQL_PARAM{name = [<<"time">>]}, 15, m
                                                                ],
                                                         type = timestamp}
                                            ]},
                   local_key = #key_v1{
                                  ast = [
-                                        ?PARAM{name = [<<"geohash">>]},
-                                        ?PARAM{name = [<<"user">>]},
-                                        ?PARAM{name = [<<"time">>]}
+                                        ?SQL_PARAM{name = [<<"geohash">>]},
+                                        ?SQL_PARAM{name = [<<"user">>]},
+                                        ?SQL_PARAM{name = [<<"time">>]}
                                        ]}
                  },
     ?assertEqual(Expected, Got).
@@ -182,21 +182,21 @@ create_all_types_sql_test() ->
                   partition_key =
                       #key_v1{
                          ast = [
-                                ?PARAM{name = [<<"user">>]},
-                                ?PARAM{name = [<<"geohash">>]},
+                                ?SQL_PARAM{name = [<<"user">>]},
+                                ?SQL_PARAM{name = [<<"geohash">>]},
                                 #hash_fn_v1{mod  = riak_ql_quanta,
                                             fn   = quantum,
                                             args = [
-                                                    ?PARAM{name = [<<"time">>]}, 15, m
+                                                    ?SQL_PARAM{name = [<<"time">>]}, 15, m
                                                    ],
                                             type = timestamp}
                                ]},
                   local_key =
                       #key_v1{
                          ast = [
-                                ?PARAM{name = [<<"user">>]},
-                                ?PARAM{name = [<<"geohash">>]},
-                                ?PARAM{name = [<<"time">>]}
+                                ?SQL_PARAM{name = [<<"user">>]},
+                                ?SQL_PARAM{name = [<<"geohash">>]},
+                                ?SQL_PARAM{name = [<<"time">>]}
                                ]}
                  },
     ?assertEqual(Expected, Got).
@@ -340,15 +340,15 @@ no_quanta_in_primary_key_is_ok_test() ->
            partition_key =
                #key_v1{
                   ast = [
-                         ?PARAM{name = [<<"a">>]},
-                         ?PARAM{name = [<<"b">>]}
+                         ?SQL_PARAM{name = [<<"a">>]},
+                         ?SQL_PARAM{name = [<<"b">>]}
                         ]},
            local_key =
                #key_v1{
                   ast = [
-                         ?PARAM{name = [<<"a">>]},
-                         ?PARAM{name = [<<"b">>]},
-                         ?PARAM{name = [<<"c">>]}
+                         ?SQL_PARAM{name = [<<"a">>]},
+                         ?SQL_PARAM{name = [<<"b">>]},
+                         ?SQL_PARAM{name = [<<"c">>]}
                         ]}},
         []},
         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Table_def))
@@ -454,11 +454,11 @@ quantum_fn_last_arg_no_quotes_required_test() ->
     {ok, {?DDL{ partition_key = #key_v1{ ast = PKAST } }, _}} =
         riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def)),
     ?assertEqual(
-        [?PARAM{name = [<<"a">>]},
-         ?PARAM{name = [<<"b">>]},
+        [?SQL_PARAM{name = [<<"a">>]},
+         ?SQL_PARAM{name = [<<"b">>]},
          #hash_fn_v1{mod = riak_ql_quanta,
                      fn = quantum,
-                     args = [?PARAM{name = [<<"c">>]}, 15, s],
+                     args = [?SQL_PARAM{name = [<<"c">>]}, 15, s],
                      type = timestamp}],
         PKAST
       ).

--- a/test/parser_create_table_tests.erl
+++ b/test/parser_create_table_tests.erl
@@ -78,20 +78,20 @@ create_timeseries_sql_test() ->
                            ],
                   partition_key = #key_v1{
                                      ast = [
-                                            #param_v1{name = [<<"geohash">>]},
-                                            #param_v1{name = [<<"user">>]},
+                                            ?PARAM{name = [<<"geohash">>]},
+                                            ?PARAM{name = [<<"user">>]},
                                             #hash_fn_v1{mod  = riak_ql_quanta,
                                                         fn   = quantum,
                                                         args = [
-                                                                #param_v1{name = [<<"time">>]}, 15, m
+                                                                ?PARAM{name = [<<"time">>]}, 15, m
                                                                ],
                                                         type = timestamp}
                                            ]},
                   local_key = #key_v1{
                                  ast = [
-                                        #param_v1{name = [<<"geohash">>]},
-                                        #param_v1{name = [<<"user">>]},
-                                        #param_v1{name = [<<"time">>]}
+                                        ?PARAM{name = [<<"geohash">>]},
+                                        ?PARAM{name = [<<"user">>]},
+                                        ?PARAM{name = [<<"time">>]}
                                        ]}
                  },
     ?assertEqual(Expected, Got).
@@ -182,21 +182,21 @@ create_all_types_sql_test() ->
                   partition_key =
                       #key_v1{
                          ast = [
-                                #param_v1{name = [<<"user">>]},
-                                #param_v1{name = [<<"geohash">>]},
+                                ?PARAM{name = [<<"user">>]},
+                                ?PARAM{name = [<<"geohash">>]},
                                 #hash_fn_v1{mod  = riak_ql_quanta,
                                             fn   = quantum,
                                             args = [
-                                                    #param_v1{name = [<<"time">>]}, 15, m
+                                                    ?PARAM{name = [<<"time">>]}, 15, m
                                                    ],
                                             type = timestamp}
                                ]},
                   local_key =
                       #key_v1{
                          ast = [
-                                #param_v1{name = [<<"user">>]},
-                                #param_v1{name = [<<"geohash">>]},
-                                #param_v1{name = [<<"time">>]}
+                                ?PARAM{name = [<<"user">>]},
+                                ?PARAM{name = [<<"geohash">>]},
+                                ?PARAM{name = [<<"time">>]}
                                ]}
                  },
     ?assertEqual(Expected, Got).
@@ -340,15 +340,15 @@ no_quanta_in_primary_key_is_ok_test() ->
            partition_key =
                #key_v1{
                   ast = [
-                         #param_v1{name = [<<"a">>]},
-                         #param_v1{name = [<<"b">>]}
+                         ?PARAM{name = [<<"a">>]},
+                         ?PARAM{name = [<<"b">>]}
                         ]},
            local_key =
                #key_v1{
                   ast = [
-                         #param_v1{name = [<<"a">>]},
-                         #param_v1{name = [<<"b">>]},
-                         #param_v1{name = [<<"c">>]}
+                         ?PARAM{name = [<<"a">>]},
+                         ?PARAM{name = [<<"b">>]},
+                         ?PARAM{name = [<<"c">>]}
                         ]}},
         []},
         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Table_def))
@@ -454,11 +454,11 @@ quantum_fn_last_arg_no_quotes_required_test() ->
     {ok, {?DDL{ partition_key = #key_v1{ ast = PKAST } }, _}} =
         riak_ql_parser:parse(riak_ql_lexer:get_tokens(Table_def)),
     ?assertEqual(
-        [#param_v1{name = [<<"a">>]},
-         #param_v1{name = [<<"b">>]},
+        [?PARAM{name = [<<"a">>]},
+         ?PARAM{name = [<<"b">>]},
          #hash_fn_v1{mod = riak_ql_quanta,
                      fn = quantum,
-                     args = [#param_v1{name = [<<"c">>]}, 15, s],
+                     args = [?PARAM{name = [<<"c">>]}, 15, s],
                      type = timestamp}],
         PKAST
       ).


### PR DESCRIPTION
Like `?DDL`, so that version changes in the record name do not affect the rest of the code.

This is in advance of the DDL upgrade and down work, to ease changes in so I don't have to merge whenever a function head is modified.
