### PR TITLE
uniformly name FP-handling lexer helpers, to be used in riak_shell lexer

### DIFF
--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -165,9 +165,9 @@ post_p([], Acc) ->
 post_p([{identifier, TokenChars} | T], Acc) when is_list(TokenChars)->
     post_p(T, [{identifier, list_to_binary(TokenChars)} | Acc]);
 post_p([{float, TokenChars} | T], Acc) ->
-    post_p(T, [{float, parse_float(TokenChars)} | Acc]);
+    post_p(T, [{float, fpdec_to_float(TokenChars)} | Acc]);
 post_p([{float_sci, TokenChars} | T], Acc) ->
-    post_p(T, [{float, sci_to_float(TokenChars)} | Acc]);
+    post_p(T, [{float, fpsci_to_float(TokenChars)} | Acc]);
 post_p([H | T], Acc) ->
     post_p(T, [H | Acc]).
 
@@ -199,7 +199,7 @@ accurate_strip(S, C) ->
             S
     end.
 
-sci_to_float(Chars) ->
+fpsci_to_float(Chars) ->
     [Mantissa, Exponent] = re:split(Chars, "E|e", [{return, list}]),
     M2 = normalise_mant(Mantissa),
     E2 = normalise_exp(Exponent),
@@ -219,9 +219,9 @@ normalise_exp("+" ++ No) -> "+" ++ No;
 normalise_exp("-" ++ No) -> "-" ++ No;
 normalise_exp(No)        -> "+" ++ No.
 
-parse_float([$- | _RemainTokenChars] = TokenChars) ->
+fpdec_to_float([$- | _RemainTokenChars] = TokenChars) ->
     list_to_float(TokenChars);
-parse_float([$. | _RemainTokenChars] = TokenChars) ->
+fpdec_to_float([$. | _RemainTokenChars] = TokenChars) ->
     list_to_float([$0 | TokenChars]);
-parse_float(TokenChars) ->
+fpdec_to_float(TokenChars) ->
     list_to_float(TokenChars).


### PR DESCRIPTION
RTS-1313

Required by https://github.com/basho/riak_shell/pull/49. (Strictly speaking, there are simple renames in this PR, but those still make sense as the two were named somewhat inconsistently.)
