### PR TITLE
Clean-up as per RTS-900

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
 {escript_incl_apps, [sext]}.
 
 {deps, [
-        {unite, "", {git, "https://github.com/basho/unite.git", {tag, "v0.0.1p2"}}},
+        {unite, "", {git, "https://github.com/basho/unite.git", {tag, "v0.0.1p1"}}},
         {sext, ".*", {git, "https://github.com/basho/sext.git", {tag, "1.1p6"}}},
         {mochiweb, ".*", {git, "https://github.com/basho/mochiweb.git", {tag, "v2.9.0p2"}}},
         {merl, ".*", {git, "https://github.com/basho/merl.git", {tag, "0.1.0-basho"}}}


### PR DESCRIPTION
- Removed unnecessary recursion from find_local_key/1 and find_partition_key/1.
- get_func_type/1 is now individual function clauses.
- make_funcall/4 added and called from make-funcall/2. It uses the function type to decide what to do in its function clauses.
- extract_key_field_list/2 now maps an extractor function over the elements instead of the convoluted recursive function
  which had an argument Extracted, that was never used for anything.
- find_fields/3 has been replaced by a direct recursive function.
