### PR TITLE
Support hex literals in SQL RTS-1401

### DIFF
--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -38,6 +38,7 @@ WHERE = (W|w)(H|h)(E|e)(R|r)(E|e)
 WITH = (W|w)(I|i)(T|t)(H|h)
 
 CHARACTER_LITERAL = ('([^\']|(\'\'))*')
+HEX = 0x([0-9a-zA-Z]*)
 
 REGEX = (/[^/][a-zA-Z0-9\*\.]+/i?)
 
@@ -105,6 +106,7 @@ Rules.
 {WHERE} : {token, {where, list_to_binary(TokenChars)}}.
 {WITH} : {token, {with, list_to_binary(TokenChars)}}.
 
+{HEX} : {token, {character_literal, clean_up_hex(TokenChars)}}.
 {INTNUM}   : {token, {integer, list_to_integer(TokenChars)}}.
 
 % float chars do not get converted to floats, if they are part of a word
@@ -176,6 +178,14 @@ post_p([H | T], Acc) ->
 lex(String) ->
     {ok, Toks, _} = string(String),
     Toks.
+
+clean_up_hex([$0,$x|Hex]) ->
+    case length(Hex) rem 2 of
+        0 ->
+            mochihex:to_bin(Hex);
+        _ ->
+            error({odd_hex_chars,<<"Hex strings must have an even number of characters.">>})
+    end.
 
 clean_up_literal(Literal) ->
     RemovedOutsideQuotes = accurate_strip(Literal, $'),

--- a/test/parser_select_tests.erl
+++ b/test/parser_select_tests.erl
@@ -281,6 +281,26 @@ select_hex_all_chars_test() ->
         proplists:lookup(where, Parsed_query)
     ).
 
+select_empty_hex_test() ->
+    Query_sql =
+        "SELECT * FROM mytab "
+        "WHERE a = 0x",
+    {select, Parsed_query} = riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Query_sql)),
+    ?assertEqual(
+        {where, [{'=', <<"a">>, {binary, << >>}}]},
+        proplists:lookup(where, Parsed_query)
+    ).
+
+select_empty_hex_not_as_final_token_test() ->
+    Query_sql =
+        "SELECT * FROM mytab "
+        "WHERE a = 0x AND b = 10",
+    {select, Parsed_query} = riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Query_sql)),
+    ?assertEqual(
+        {where, [{and_, {'=', <<"a">>, {binary, << >>}}, {'=',<<"b">>,{integer,10}}}]},
+        proplists:lookup(where, Parsed_query)
+    ).
+
 select_hex_odd_number_of_chars_in_hex_test() ->
     Query_sql =
         "SELECT * FROM mytab "

--- a/test/parser_select_tests.erl
+++ b/test/parser_select_tests.erl
@@ -301,6 +301,16 @@ select_empty_hex_not_as_final_token_test() ->
         proplists:lookup(where, Parsed_query)
     ).
 
+select_empty_hex_pattern_in_single_quotes_test() ->
+    Query_sql =
+        "SELECT * FROM mytab "
+        "WHERE a = '0xABABABAB'",
+    {select, Parsed_query} = riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Query_sql)),
+    ?assertEqual(
+        {where, [{'=', <<"a">>, {binary, <<"0xABABABAB">>}}]},
+        proplists:lookup(where, Parsed_query)
+    ).
+
 select_hex_odd_number_of_chars_in_hex_test() ->
     Query_sql =
         "SELECT * FROM mytab "

--- a/test/parser_select_tests.erl
+++ b/test/parser_select_tests.erl
@@ -259,3 +259,47 @@ field_in_aggregate_function_does_not_have_to_be_in_group_by_test() ->
         {select, [_|_]},
         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Query_sql))
     ).
+
+select_hex_test() ->
+    Query_sql =
+        "SELECT * FROM mytab "
+        "WHERE a = 0xDEADBEEF",
+    {select, Parsed_query} = riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Query_sql)),
+    ?assertEqual(
+        {where, [{'=', <<"a">>, {binary, mochihex:to_bin("DEADBEEF")}}]},
+        proplists:lookup(where, Parsed_query)
+    ).
+
+select_hex_all_chars_test() ->
+    All_chars = "0123456789aBbBcCdDeEfF",
+    Query_sql =
+        "SELECT * FROM mytab "
+        "WHERE a = 0x"++All_chars,
+    {select, Parsed_query} = riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Query_sql)),
+    ?assertEqual(
+        {where, [{'=', <<"a">>, {binary, mochihex:to_bin(All_chars)}}]},
+        proplists:lookup(where, Parsed_query)
+    ).
+
+select_hex_odd_number_of_chars_in_hex_test() ->
+    Query_sql =
+        "SELECT * FROM mytab "
+        "WHERE a = 0x0DDBEEF",
+    ?assertException(
+        error, {odd_hex_chars, <<"Hex strings must have an even number of characters.">>},
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Query_sql))
+    ).
+
+select_hex_and_char_literals_parse_the_same_test() ->
+    Text = "QWERTY",
+    Varchar_sql =
+      "SELECT * FROM mytab "
+      "WHERE a = '"++Text++"'" ,
+    Hex_sql =
+      "SELECT * FROM mytab "
+      "WHERE a = 0x"++mochihex:to_hex(Text),
+    ?assertEqual(
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Varchar_sql)),
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Hex_sql))
+    ).
+


### PR DESCRIPTION
Part of support for the BLOB type, where not all binary data can be queried via printable characters.

The syntax is the following:

``` sql
SELECT * FROM mytab
WHERE mycol = 0xDEADBEEF
```
