### PR TITLE
TS Insert NULL support

### DIFF
--- a/include/riak_ql_ddl.hrl
+++ b/include/riak_ql_ddl.hrl
@@ -64,4 +64,6 @@
 -define(DDL_RECORD_NAME, ddl_v1).
 -define(DDL_RECORD_VERSION, 1).
 
+-define(SQL_NULL, []).
+
 -endif.

--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -628,16 +628,16 @@ insert_sql_columns_row_values(FInQuery, Values) ->
                     [ {null, ?SQL_NULL} || _I <- lists:seq(length(Values) + 1, length(FInQuery)) ]
             end
     end,
-    lists:foldr(fun ({Type, Value}, Acc) ->
-                TV = case {Type, Value} of
+    lists:map(fun ({Type, Value}) ->
+                case {Type, Value} of
                     %% implicit NULL
                     {null, ?SQL_NULL} -> {null, ?SQL_NULL};
                     %% explicit NULL
                     {null, <<_Null/binary>>} -> {null, ?SQL_NULL};
                     {Type, Value} -> {Type, Value}
-                end,
-                [TV|Acc]
-        end, [], Values1).
+                end
+        end,
+        Values1).
 
 %% Get the type of a field from the DDL datastructure.
 %%

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -37,12 +37,12 @@ VARCHAR = (V|v)(A|a)(R|r)(C|c)(H|h)(A|a)(R|r)
 WHERE = (W|w)(H|h)(E|e)(R|r)(E|e)
 WITH = (W|w)(I|i)(T|t)(H|h)
 
-CHARACTER_LITERAL = ('([^\']|(\'\'))*')
+CHARACTER_LITERAL = '(''|[^'\n])*'
 
 REGEX = (/[^/][a-zA-Z0-9\*\.]+/i?)
 
-QUOTED = ("([^\"]|(\"\"))*")
 IDENTIFIER = ([a-zA-Z][a-zA-Z0-9_\-]*)
+QUOTED_IDENTIFIER = \"(\"\"|[^\"\n])*\"
 WHITESPACE = ([\000-\s]*)
 
 % characters not in the ascii range
@@ -134,8 +134,6 @@ Rules.
 {CHARACTER_LITERAL} :
   {token, {character_literal, clean_up_literal(TokenChars)}}.
 
-{QUOTED} : {token, {identifier, strip_quoted(TokenChars)}}.
-
 {REGEX} : {token, {regex, list_to_binary(TokenChars)}}.
 
 {COMMA} : {token, {comma, list_to_binary(TokenChars)}}.
@@ -145,7 +143,8 @@ Rules.
 
 \n : {end_token, {'$end'}}.
 
-{IDENTIFIER} : {token, {identifier, list_to_binary(TokenChars)}}.
+{IDENTIFIER} : {token, {identifier, clean_up_identifier(TokenChars)}}.
+{QUOTED_IDENTIFIER} : {token, {identifier, clean_up_identifier(TokenChars)}}.
 {UNICODE} : error(unicode_in_identifier).
 
 .  : error(iolist_to_binary(io_lib:format("Unexpected token '~s'.", [TokenChars]))).
@@ -177,19 +176,31 @@ lex(String) ->
     {ok, Toks, _} = string(String),
     Toks.
 
+clean_up_identifier(Literal) ->
+    clean_up_literal(Literal).
+
 clean_up_literal(Literal) ->
-    RemovedOutsideQuotes = accurate_strip(Literal, $'),
-    DeDoubledInternalQuotes = re:replace(RemovedOutsideQuotes,
-                                         "''", "'",
-                                         [global, {return, list}]),
-    list_to_binary(DeDoubledInternalQuotes).
+    Literal1 = case hd(Literal) of
+        $' -> accurate_strip(Literal, $');
+        $" ->
+            [error(unicode_in_quotes) || U <- Literal, U > 127],
+            accurate_strip(Literal, $");
+        _ -> Literal
+    end,
+    DeDupedInternalQuotes = dedup_quotes(Literal1),
+    list_to_binary(DeDupedInternalQuotes).
 
-strip_quoted(QuotedString) ->
-    % if there are unicode characters in the string, throw an error
-    [error(unicode_in_quotes) || U <- QuotedString, U > 127],
-
-    StrippedOutsideQuotes = accurate_strip(QuotedString, $"),
-    re:replace(StrippedOutsideQuotes, "\"\"", "\"", [global, {return, binary}]).
+%% dedup(licate) quotes, using pattern matching to reduce to O(n)
+dedup_quotes(S) ->
+    dedup_quotes(S, []).
+dedup_quotes([], Acc) ->
+    lists:reverse(Acc);
+dedup_quotes([H0,H1|T], Acc) when H0 =:= $' andalso H1 =:= $' ->
+    dedup_quotes(T, [H0|Acc]);
+dedup_quotes([H0,H1|T], Acc) when H0 =:= $" andalso H1 =:= $" ->
+    dedup_quotes(T, [H0|Acc]);
+dedup_quotes([H|T], Acc) ->
+    dedup_quotes(T, [H|Acc]).
 
 %% only strip one quote, to accept Literals ending in the quote
 %% character being stripped

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -376,6 +376,7 @@ RowValueList -> RowValueList comma left_paren RowValue right_paren : '$1' ++ ['$
 RowValue -> RowValue comma FieldValue : '$1' ++ ['$3'].
 RowValue -> FieldValue : ['$1'].
 
+FieldValue -> null : '$1'.
 FieldValue -> integer : '$1'.
 FieldValue -> float : '$1'.
 FieldValue -> TruthValue : '$1'.

--- a/src/riak_ql_window_agg_fns.erl
+++ b/src/riak_ql_window_agg_fns.erl
@@ -30,8 +30,6 @@
 -export([fn_arity/1]).
 -export([fn_type_signature/2]).
 
--define(SQL_NULL, []).
-
 -type aggregate_function() :: 'COUNT' | 'SUM' | 'AVG' |'MEAN' | 'MIN' | 'MAX' | 'STDDEV' | 'STDDEV_POP' | 'STDDEV_SAMP'.
 
 -include("riak_ql_ddl.hrl").

--- a/test/parser_insert_tests.erl
+++ b/test/parser_insert_tests.erl
@@ -92,3 +92,14 @@ insert_null_case_insensitive_test() ->
                                     {values,[[{null,<<"NuLl">>}]]}]},
         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Insert_sql))
     ).
+
+insert_identifier_test() ->
+    Insert_sql =
+        "INSERT INTO mytab (col) VALUES (john)",
+    ?assertEqual(
+        {insert,[{table,<<"mytab">>},
+                                    {fields,[{identifier,[<<"col">>]}]},
+                                    {values,[[{identifier,<<"john">>}]]}]},
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Insert_sql))
+    ).
+

--- a/test/parser_insert_tests.erl
+++ b/test/parser_insert_tests.erl
@@ -93,6 +93,16 @@ insert_null_case_insensitive_test() ->
         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Insert_sql))
     ).
 
+insert_literal_null_test() ->
+    Insert_sql =
+        "INSERT INTO mytab (col) VALUES ('null')",
+    ?assertEqual(
+        {insert,[{table,<<"mytab">>},
+                                    {fields,[{identifier,[<<"col">>]}]},
+                                    {values,[[{binary,<<"null">>}]]}]},
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Insert_sql))
+    ).
+
 insert_identifier_test() ->
     Insert_sql =
         "INSERT INTO mytab (col) VALUES (john)",

--- a/test/parser_insert_tests.erl
+++ b/test/parser_insert_tests.erl
@@ -72,3 +72,23 @@ insert_sint64_test() ->
                                      {values,[[{integer,22}]]}]},
         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Insert_sql))
     ).
+
+insert_null_test() ->
+    Insert_sql =
+        "INSERT INTO mytab (col) VALUES (NULL)",
+    ?assertEqual(
+        {insert,[{table,<<"mytab">>},
+                                    {fields,[{identifier,[<<"col">>]}]},
+                                    {values,[[{null,<<"NULL">>}]]}]},
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Insert_sql))
+    ).
+
+insert_null_case_insensitive_test() ->
+    Insert_sql =
+        "INSERT INTO mytab (col) VALUES (NuLl)",
+    ?assertEqual(
+        {insert,[{table,<<"mytab">>},
+                                    {fields,[{identifier,[<<"col">>]}]},
+                                    {values,[[{null,<<"NuLl">>}]]}]},
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Insert_sql))
+    ).


### PR DESCRIPTION
is depended upon by:
- https://github.com/basho/riak_kv/pull/1507

does:
- for Riak TS insert support for NULL values, implicitly and explicitly, changed riak_ql_ddl:insert_sql_columns/3 to allow the ddl module to flesh out fields and values not specified in the query.

While the column reordering may look like a bunch of avoidable work (reduced dev- and run-time), this feature is already published as supported w/i Riak TS documentation, but was not actually supported prior to this work, see:
http://docs.basho.com/riak/ts/1.4.0/using/writingdata/#adding-data-via-sql

> As with standard SQL, if all of the field names are not provided before the VALUES keyword, the other fields are assumed to be null.
> 
> The fields can be in any order, but the field name and the values must match up. Without the VALUES keyword, all fields must be present in the same order as the schema definition.
