### PR TITLE
Allow the timestamp type as an argument in aggregate functions RTS-1286

### DIFF
--- a/src/riak_ql_window_agg_fns.erl
+++ b/src/riak_ql_window_agg_fns.erl
@@ -41,19 +41,25 @@
         riak_ql_ddl:simple_field_type().
 fn_type_signature('AVG', [double]) -> double;
 fn_type_signature('AVG', [sint64]) -> double;
+fn_type_signature('AVG', [timestamp]) -> double;
 fn_type_signature('COUNT', [_]) -> sint64;
 fn_type_signature('MAX', [double]) -> double;
 fn_type_signature('MAX', [sint64]) -> sint64;
+fn_type_signature('MAX', [timestamp]) -> sint64;
 fn_type_signature('MEAN', Args) -> fn_type_signature('AVG', Args);
 fn_type_signature('MIN', [double]) -> double;
 fn_type_signature('MIN', [sint64]) -> sint64;
+fn_type_signature('MIN', [timestamp]) -> sint64;
 fn_type_signature('STDDEV', Args) -> fn_type_signature('STDDEV_SAMP', Args);
 fn_type_signature('STDDEV_POP', [double]) -> double;
 fn_type_signature('STDDEV_POP', [sint64]) -> double;
+fn_type_signature('STDDEV_POP', [timestamp]) -> double;
 fn_type_signature('STDDEV_SAMP', [double]) -> double;
 fn_type_signature('STDDEV_SAMP', [sint64]) -> double;
+fn_type_signature('STDDEV_SAMP', [timestamp]) -> double;
 fn_type_signature('SUM', [double]) -> double;
 fn_type_signature('SUM', [sint64]) -> sint64;
+fn_type_signature('SUM', [timestamp]) -> sint64;
 fn_type_signature(Fn, Args) ->
     {error, {argument_type_mismatch, Fn, Args}}.
 


### PR DESCRIPTION
These functions operate on any number type, which timestamp is stored as so timestamps and these functions are already compatible. This change adds timestamp to the type check of the function signature.
