### PR TITLE
Require that a local key is specified RTS-1130

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ _build
 rebar.lock
 .local_dialyzer_plt
 riak_ql
+dialyzer_unhandled_warnings
+dialyzer_warnings

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,0 +1,2 @@
+riak_ql_parser.yrl
+riak_ql_parser.erl

--- a/test/parser_create_table_tests.erl
+++ b/test/parser_create_table_tests.erl
@@ -538,3 +538,26 @@ partition_key_quantum_with_duplicate_fields_is_not_allowed_test() ->
         {error,{0,riak_ql_parser,<<"Primary key has duplicate fields (c)">>}},
         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Table_def))
     ).
+
+%% definition for a primary key without brackets for the local key
+missing_local_key_and_local_key_brackets_test() ->
+    Table_def =
+        "CREATE TABLE mytab1 ("
+        "a varchar NOT NULL, "
+        "ts timestamp NOT NULL, "
+        "PRIMARY KEY(quantum(ts,30,'d')) );",
+    ?assertEqual(
+        {error,{0,riak_ql_parser,<<"No local key specified.">>}},
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Table_def))
+    ).
+
+missing_local_keys_test() ->
+    Table_def =
+        "CREATE TABLE mytab1 ("
+        "a varchar NOT NULL, "
+        "ts timestamp NOT NULL, "
+        "PRIMARY KEY((quantum(ts,30,'d'))) );",
+    ?assertEqual(
+        {error,{0,riak_ql_parser,<<"No local key specified.">>}},
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Table_def))
+    ).


### PR DESCRIPTION
Require that a local key is always specified as part of the `PRIMARY KEY` syntax, otherwise an error message is returned explaining that the local key is missing. Previously the partition key was copied as the local key which would then cause errors because it cannot handle partition key specific features like the quantum function.