### PR TITLE
The EQC generator was only testing 2 of the 4 code paths for quantums

### DIFF
--- a/src/riak_ql_quanta.erl
+++ b/src/riak_ql_quanta.erl
@@ -253,9 +253,15 @@ date_gen() ->
 time_gen() ->
     {choose(0, 23), choose(0, 59), choose(0, 59)}.
 
+%% We expect quanta to be bigger than their cardinality
+%% A quantum of 100 minutes is perfectly reasonable
 quantum_gen() ->
-    oneof([ {choose(1,2000), h},
-            {choose(1, 60), m}]).
+    oneof([ 
+            {choose(1, 1000), d},
+            {choose(1, 1000), h},
+            {choose(1, 1000), m},
+            {choose(1, 1000), s}
+          ]).
 
 -endif.
 -endif.


### PR DESCRIPTION
This bug was originally raised against a redundant module in riak_kv
https://github.com/basho/riak_kv/pull/1489