### PR TITLE
Remove `testclean` from the test cycle

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,6 +1,6 @@
 minimum_reviewers: 2
 build_steps:
- - make clean
+ - make clean deps compile
  - make test
  - make xref
  - make dialyzer

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ clean:
 distclean: clean
 	./rebar delete-deps
 
-testclean: clean
-	@rm -rf eunit.log .eunit/*
-
-test: testclean compile
+test:
+	@# delete the lexer and parser beams because the rebar2 will not
+	@# recompile them on changes
+	@rm -f .eunit/riak_ql_parser.beam .eunit/riak_ql_lexer.beam
 	./rebar eunit skip_deps=true
 
 DIALYZER_APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- erlang -*-
-{cover_enabled, true}.
+{cover_enabled, false}.
 {erl_opts, [
 	    debug_info,
 	    warnings_as_errors,


### PR DESCRIPTION
Remove the full test clean from the Makefile, which also cleaned deps on every test cycle and made the test target very slow. Now, just rm the parser and lexer because the compiler does not detect changes.