### PR TITLE
Support Comments in SQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,11 @@ distclean: clean
 test:
 	@# delete the lexer and parser beams because the rebar2 will not
 	@# recompile them on changes
-	@rm -f .eunit/riak_ql_parser.beam .eunit/riak_ql_lexer.beam
-	./rebar eunit skip_deps=true
+	@rm -f src/riak_ql_parser.erl src/riak_ql_lexer.erl \
+	      ebin/riak_ql_parser.beam ebin/riak_ql_parser.* \
+	      .eunit/riak_ql_parser.* .eunit/riak_ql_lexer.*
+	@# call the compile target as well, also needed for the lexer/parser files
+	./rebar compile eunit skip_deps=true
 
 DIALYZER_APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
 	xmerl webtool snmp public_key mnesia eunit syntax_tools compiler

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -46,6 +46,7 @@ REGEX = (/[^/][a-zA-Z0-9\*\.]+/i?)
 
 IDENTIFIER = ([a-zA-Z][a-zA-Z0-9_\-]*)
 QUOTED_IDENTIFIER = \"(\"\"|[^\"\n])*\"
+COMMENT_MULTILINE = /\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/
 WHITESPACE = ([\000-\s]*)
 
 % characters not in the ascii range
@@ -145,6 +146,7 @@ Rules.
 {COMMA} : {token, {comma, list_to_binary(TokenChars)}}.
 {SEMICOLON} : {token, {semicolon, list_to_binary(TokenChars)}}.
 
+{COMMENT_MULTILINE} : skip_token.
 {WHITESPACE} : skip_token.
 
 \n : {end_token, {'$end'}}.

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -46,7 +46,7 @@ REGEX = (/[^/][a-zA-Z0-9\*\.]+/i?)
 
 IDENTIFIER = ([a-zA-Z][a-zA-Z0-9_\-]*)
 QUOTED_IDENTIFIER = \"(\"\"|[^\"\n])*\"
-COMMENT_MULTILINE = (/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/)||(--.*)
+COMMENT_MULTILINE = (/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/)|(--.*)
 WHITESPACE = ([\000-\s]*)
 
 % characters not in the ascii range

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -46,7 +46,7 @@ REGEX = (/[^/][a-zA-Z0-9\*\.]+/i?)
 
 IDENTIFIER = ([a-zA-Z][a-zA-Z0-9_\-]*)
 QUOTED_IDENTIFIER = \"(\"\"|[^\"\n])*\"
-COMMENT_MULTILINE = /\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/
+COMMENT_MULTILINE = (/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/)||(--.*)
 WHITESPACE = ([\000-\s]*)
 
 % characters not in the ascii range

--- a/test/parser_select_tests.erl
+++ b/test/parser_select_tests.erl
@@ -373,3 +373,33 @@ multiple_multiline_comment_in_select_test() ->
             "SELECT * FROM mytab /* oh\n"
             "hai */ /* hi again */ WHERE a = 'val'"))
     ).
+
+single_line_comment_in_select_test() ->
+    ?assertEqual(
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE a = 'val'")),
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab WHERE a = 'val' -- a comment"))
+    ).
+
+single_line_comment_in_multiline_select_test() ->
+    ?assertEqual(
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE a = 'val'")),
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab -- a comment\n"
+            "WHERE a = 'val'"))
+    ).
+
+
+single_line_comment_in_multiline_ctrl_select_test() ->
+    ?assertEqual(
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE a = 'val'")),
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab -- a comment\r\n"
+            "WHERE a = 'val'"))
+    ).

--- a/test/parser_select_tests.erl
+++ b/test/parser_select_tests.erl
@@ -333,3 +333,43 @@ select_hex_and_char_literals_parse_the_same_test() ->
         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(Hex_sql))
     ).
 
+multiline_comment_on_single_line_in_select_test() ->
+    ?assertEqual(
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE a = 'val'")),
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+           "SELECT * FROM mytab /* hi */ "
+           "WHERE a = 'val'"))
+    ).
+
+multiline_comment_in_select_test() ->
+    ?assertEqual(
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE a = 'val'")),
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab /* oh\n"
+            "hai */ WHERE a = 'val'"))
+    ).
+
+multiline_comment_with_asterisk_inside_in_select_test() ->
+    ?assertEqual(
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE a = 'val'")),
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab /** *\n"
+            " * / / *\n"
+            "hai */ WHERE a = 'val'"))
+    ).
+
+multiple_multiline_comment_in_select_test() ->
+    ?assertEqual(
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE a = 'val'")),
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab /* oh\n"
+            "hai */ /* hi again */ WHERE a = 'val'"))
+    ).


### PR DESCRIPTION
Comments come in two varieties in SQL, the multiline kind:

```sql
/* a multiline comment
   same as in c++ or java
*/
```
Or a single line comment, like an `%` in erlang:
```sql
SELECT * FROM mytable; -- this is my comment
```
Implementing this now because some of our example SQL snippets in the docs do not parse because of comment syntax we do not support.