### PR TITLE
RTS-1403: Add SHOW CREATE TABLE command

### DIFF
--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -74,6 +74,7 @@ TruthValue
 BooleanPrimary
 BooleanPredicand
 
+ShowCreateTable
 CreateTable
 PrimaryKey
 FunArg
@@ -184,6 +185,7 @@ NullOrderSpec -> nulls last : {nulls_last, <<"nulls last">>}.
 StatementWithoutSemicolon -> Query           : convert('$1').
 StatementWithoutSemicolon -> TableDefinition : fix_up_keys('$1').
 StatementWithoutSemicolon -> Describe : '$1'.
+StatementWithoutSemicolon -> ShowCreateTable : '$1'.
 StatementWithoutSemicolon -> Explain : '$1'.
 StatementWithoutSemicolon -> Insert : '$1'.
 StatementWithoutSemicolon -> ShowTables : '$1'.
@@ -198,6 +200,9 @@ Explain -> explain Query : make_explain('$2').
 
 %% 20.9 DESCRIBE STATEMENT
 Describe -> describe Bucket : make_describe('$2').
+
+%% SHOW CREATE TABLE
+ShowCreateTable -> show create table Bucket : make_show_create_table('$4').
 
 Insert -> insert into Identifier OptFieldList values RowValueList : make_insert('$3', '$4', '$6').
 
@@ -625,6 +630,12 @@ wrap_identifier(Default) -> Default.
 make_describe({identifier, D}) ->
     [
      {type, describe},
+     {identifier, D}
+    ].
+
+make_show_create_table({identifier, D}) ->
+    [
+     {type, show_create_table},
      {identifier, D}
     ].
 

--- a/src/riak_ql_show_create_table.erl
+++ b/src/riak_ql_show_create_table.erl
@@ -1,0 +1,118 @@
+%%-------------------------------------------------------------------
+%%
+%% SHOW CREATE TABLE SQL command
+%%
+%% These are retrieved from riak_core_bucket:get_bucket/1
+%%
+%% Copyright (C) 2016 Basho Technologies, Inc. All rights reserved
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%%-------------------------------------------------------------------
+
+-module(riak_ql_show_create_table).
+
+-export([show_create_table/2]).
+
+-include("riak_ql_ddl.hrl").
+
+%%
+-spec show_create_table(?DDL{}, [tuple()]) -> {ok, {ColNames::[binary()],
+                                               ColTypes::[riak_ql_ddl:simple_field_type()],
+                                               Rows::[[any()]]}}.
+
+show_create_table(DDL, Props) ->
+    FilteredProps = filter_bucket_properties(Props),
+    ColumnNames = [<<"SQL">>],
+    ColumnTypes = [varchar],
+    SQL = riak_ql_to_string:ddl_rec_to_sql_multiline(DDL, FilteredProps),
+    Rows =
+        [[SQL]],
+    {ok, {ColumnNames, ColumnTypes, Rows}}.
+
+%% Skip any internal bucket properties
+filter_bucket_properties(Props) ->
+    Filtered = lists:filter(fun({basic_quorum, _}) -> false;
+                               ({big_vclock, _}) -> false;
+                               ({chash_keyfun, _}) -> false;
+                               ({claimant, _}) -> false;
+                               ({ddl, _}) -> false;
+                               ({ddl_compiler_version, _}) -> false;
+                               ({linkfun, _}) -> false;
+                               ({name, _}) -> false;
+                               ({old_vclock, _}) -> false;
+                               ({precommit, _}) -> false;
+                               ({small_vclock, _}) -> false;
+                               ({write_once, _}) -> false;
+                               ({young_vclock, _}) -> false;
+                               (_) -> true end, Props),
+    lists:sort(fun({A,_},{B,_}) -> A =< B end, Filtered).
+
+
+%%-------------------------------------------------------------------
+%% Unit tests
+%%-------------------------------------------------------------------
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+matching_sql_test() ->
+    SQL = "CREATE TABLE tab ("
+    "a VARCHAR   NOT NULL, "
+    "b VARCHAR   NOT NULL, "
+    "c TIMESTAMP NOT NULL, "
+    "PRIMARY KEY ((a, b, quantum(c, 15, 'm')), a, b, c)) "
+    "WITH (a = 1, b = 'bee', c = false, d = 3.1415)",
+    Props = [{<<"a">>,1},{<<"b">>,<<"bee">>},{<<"c">>,false},{<<"d">>,3.1415}],
+    {ddl, DDL, Props} =
+        riak_ql_parser:ql_parse(
+          riak_ql_lexer:get_tokens(SQL)),
+    {ok, Result} = show_create_table(DDL, Props),
+    {Cols, _, [[Row]]} = Result,
+    ?assertEqual(
+        [<<"SQL">>],
+        Cols),
+    ?assertEqual(
+        lowercase(SQL),
+        lowercase(Row)
+    ).
+
+matching_sql_no_props_test() ->
+    SQL = "CREATE TABLE tab ("
+    "a VARCHAR   NOT NULL, "
+    "b VARCHAR   NOT NULL, "
+    "c TIMESTAMP NOT NULL, "
+    "PRIMARY KEY ((a, b, quantum(c, 15, 'm')), a, b, c))",
+    {ddl, DDL, []} =
+        riak_ql_parser:ql_parse(
+            riak_ql_lexer:get_tokens(SQL)),
+    {ok, Result} = show_create_table(DDL, []),
+    {Cols, _, [[Row]]} = Result,
+    ?assertEqual(
+        [<<"SQL">>],
+        Cols),
+    ?assertEqual(
+        lowercase(SQL),
+        lowercase(Row)
+    ).
+
+%% Remove the extra whitespace and lowercase everything for a safe comparison
+lowercase(S) when is_list(S) ->
+    SingleSpace = re:replace(S, "\\s+", " ", [global,{return,list}]),
+    string:to_lower(string:join(string:tokens(SingleSpace, " "), " "));
+lowercase(S) when is_binary(S) ->
+    lowercase(binary_to_list(S)).
+
+-endif.

--- a/src/riak_ql_to_string.erl
+++ b/src/riak_ql_to_string.erl
@@ -27,7 +27,10 @@
 
 -export([
          col_names_from_select/1,
-         ddl_rec_to_sql/1
+         ddl_rec_to_sql/1,
+         ddl_rec_to_sql/2,
+         ddl_rec_to_sql_with_props/2,
+         ddl_rec_to_sql_multiline/2
         ]).
 
 -include("riak_ql_ddl.hrl").
@@ -84,8 +87,8 @@ select_col_to_string({Op, Arg1, Arg2}) when is_atom(Op) ->
       "(~s~s~s)",
       [select_col_to_string(Arg1), op_to_string(Op), select_col_to_string(Arg2)]).
 
-op_to_string(and_) -> "and";
-op_to_string(or_) -> "or";
+op_to_string(and_) -> "AND";
+op_to_string(or_) -> "OR";
 op_to_string(Op) ->
     atom_to_list(Op).
 
@@ -93,29 +96,43 @@ flat_format(Format, Args) ->
     lists:flatten(io_lib:format(Format, Args)).
 
 -spec ddl_rec_to_sql(?DDL{}) -> string().
+ddl_rec_to_sql(DDL) ->
+    ddl_rec_to_sql(DDL, " ").
+
+-spec ddl_rec_to_sql(?DDL{}, string()) -> string().
 ddl_rec_to_sql(?DDL{table         = Tb,
                     fields        = Fs,
                     partition_key = PK,
-                    local_key     = LK}) ->
-    "CREATE TABLE " ++ binary_to_list(Tb) ++ " (" ++ make_fields(Fs) ++ "PRIMARY KEY ((" ++ pk_to_sql(PK) ++ "), " ++ lk_to_sql(LK) ++ "))".
+                    local_key     = LK},
+               Join) ->
+    "CREATE TABLE " ++ binary_to_list(Tb) ++ " (" ++ make_fields(Fs, Join) ++ "PRIMARY KEY ((" ++ pk_to_sql(PK) ++ ")," ++ Join ++ lk_to_sql(LK) ++ "))".
 
-make_fields(Fs) ->
-    make_f2(Fs, []).
+-spec ddl_rec_to_sql_with_props(?DDL{}, [tuple()]) -> string().
+ddl_rec_to_sql_with_props(DDL, Props) ->
+    ddl_rec_to_sql(DDL) ++ make_props(Props).
 
-make_f2([], Acc) ->
+-spec ddl_rec_to_sql_multiline(?DDL{}, [tuple()]) -> string().
+ddl_rec_to_sql_multiline(DDL, Props) ->
+    Join = "\n",
+    ddl_rec_to_sql(DDL, Join) ++ make_props(Props, Join).
+
+make_fields(Fs, Join) ->
+    make_f2(Fs, Join, []).
+
+make_f2([], _Join, Acc) ->
     lists:flatten(lists:reverse(Acc));
 make_f2([#riak_field_v1{name    = Nm,
                        type     = Ty,
-                       optional = IsOpt} | T], Acc) ->
+                       optional = IsOpt} | T], Join, Acc) ->
     Args = [
             binary_to_list(Nm),
-            atom_to_list(Ty)
+            string:to_upper(atom_to_list(Ty))
            ] ++ case IsOpt of
                     true  -> [];
-                    false -> ["not null"]
+                    false -> ["NOT NULL"]
                 end,
-    NewAcc = string:join(Args, " ") ++ ", ",
-    make_f2(T, [NewAcc | Acc]).
+    NewAcc = string:join(Args, " ") ++ "," ++ Join,
+    make_f2(T, Join, [NewAcc | Acc]).
 
 pk_to_sql(#key_v1{ast = [Fam, Series, TS]}) ->
     string:join([binary_to_list(extract(X?SQL_PARAM.name)) || X <- [Fam, Series]] ++ [make_q(TS)], ", ").
@@ -125,7 +142,7 @@ make_q(#hash_fn_v1{mod  = riak_ql_quanta,
                    args = Args,
                    type = timestamp}) ->
               [?SQL_PARAM{name = [Nm]}, No, Unit] = Args,
-    _Q = "quantum(" ++ string:join([binary_to_list(Nm), integer_to_list(No), "'" ++ atom_to_list(Unit) ++ "'"], ", ") ++ ")".
+    _Q = "QUANTUM(" ++ string:join([binary_to_list(Nm), integer_to_list(No), "'" ++ atom_to_list(Unit) ++ "'"], ", ") ++ ")".
 
 extract([X]) -> X.
 
@@ -139,6 +156,36 @@ param_to_string(?SQL_PARAM{name = [Name], ordering = Order}) ->
         _ ->
             binary_to_list(Name)
     end.
+
+%% Default join character is a space
+make_props(Props) ->
+    make_props(Props, " ").
+make_props([], _Join) ->
+    "";
+make_props(Props, Join) ->
+    PropList = [flat_format("~s = ~s", [prop_to_string(K), prop_to_quoted_string(V)]) || {K, V} <- Props],
+    Join ++ "WITH (" ++ string:join(PropList, "," ++ Join) ++ ")".
+
+prop_to_string(V) when is_integer(V) ->
+    integer_to_list(V);
+prop_to_string(V) when is_boolean(V) ->
+    atom_to_list(V);
+prop_to_string(V) when is_float(V) ->
+    mochinum:digits(V);
+prop_to_string(V) when is_binary(V) ->
+    binary_to_list(V);
+prop_to_string(V) when is_atom(V) ->
+    atom_to_list(V);
+prop_to_string(V) ->
+    flat_format("~p", [V]).
+
+prop_to_quoted_string(V) when is_binary(V) ->
+    flat_format("'~s'", [V]);
+prop_to_quoted_string(V) when is_list(V) ->
+    flat_format("'~s'", [V]);
+prop_to_quoted_string(V) ->
+    prop_to_string(V).
+
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -272,11 +319,11 @@ select_col_to_string_negated_parens_test() ->
 
 ddl_rec_to_string_test() ->
     SQL = "CREATE TABLE Mesa "
-          "(Uno timestamp not null, "
-          "Dos timestamp not null, "
-          "Tres timestamp not null, "
+          "(Uno TIMESTAMP NOT NULL, "
+          "Dos TIMESTAMP NOT NULL, "
+          "Tres TIMESTAMP NOT NULL, "
           "PRIMARY KEY ((Uno, Dos, "
-          "quantum(Tres, 1, 'd')), "
+          "QUANTUM(Tres, 1, 'd')), "
           "Uno, Dos, Tres))",
     Lexed = riak_ql_lexer:get_tokens(SQL),
     {ddl, DDL = ?DDL{}, _} = riak_ql_parser:ql_parse(Lexed),
@@ -285,12 +332,46 @@ ddl_rec_to_string_test() ->
         ddl_rec_to_sql(DDL)
     ).
 
+ddl_rec_to_multiline_string_test() ->
+    SQL = "CREATE TABLE Mesa "
+    "(Uno TIMESTAMP NOT NULL,\n"
+    "Dos TIMESTAMP NOT NULL,\n"
+    "Tres TIMESTAMP NOT NULL,\n"
+    "PRIMARY KEY ((Uno, Dos, "
+    "QUANTUM(Tres, 1, 'd')),\n"
+    "Uno, Dos, Tres))",
+    Lexed = riak_ql_lexer:get_tokens(SQL),
+    {ddl, DDL = ?DDL{}, _} = riak_ql_parser:ql_parse(Lexed),
+    ?assertEqual(
+        SQL,
+        ddl_rec_to_sql_multiline(DDL, [])
+    ).
+
+ddl_rec_with_props_to_string_test() ->
+    SQL = "CREATE TABLE Mesa "
+    "(Uno TIMESTAMP NOT NULL,\n"
+    "Dos TIMESTAMP NOT NULL,\n"
+    "Tres TIMESTAMP NOT NULL,\n"
+    "PRIMARY KEY ((Uno, Dos, "
+    "QUANTUM(Tres, 1, 'd')),\n"
+    "Uno, Dos, Tres))\n"
+    "WITH (a = 1,\n"
+    "b = true,\n"
+    "c = 'hola')",
+    Props = [{a, 1}, {b, true}, {c, "hola"}],
+    Lexed = riak_ql_lexer:get_tokens(SQL),
+    {ddl, DDL = ?DDL{}, _} = riak_ql_parser:ql_parse(Lexed),
+    ?assertEqual(
+        SQL,
+        ddl_rec_to_sql_multiline(DDL, Props)
+    ).
+
 ddl_rec_to_string_desc_keys_test() ->
     SQL = "CREATE TABLE mytab ("
-          "a timestamp not null, "
-          "b timestamp not null, "
-          "c timestamp not null, "
-          "PRIMARY KEY ((a, b, quantum(c, 1, 'd')), a, b, c DESC))",
+          "a TIMESTAMP NOT NULL, "
+          "b TIMESTAMP NOT NULL, "
+          "c TIMESTAMP NOT NULL, "
+          "PRIMARY KEY ((a, b, QUANTUM(c, 1, 'd')), a, b, c DESC))",
     Lexed = riak_ql_lexer:get_tokens(SQL),
     {ddl, DDL = ?DDL{}, _} = riak_ql_parser:ql_parse(Lexed),
     ?assertEqual(

--- a/test/parser_show_create_table_tests.erl
+++ b/test/parser_show_create_table_tests.erl
@@ -1,0 +1,35 @@
+%% -------------------------------------------------------------------
+%%
+%% Table SQL creation tests for the Parser
+%%
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(parser_show_create_table_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("parser_test_utils.hrl").
+
+simple_describe_test() ->
+    ?sql_comp_assert("show create table GeoCheckins", show_create_table,
+        [{identifier, <<"GeoCheckins">>}]).
+
+uppercase_quoted_describe_test() ->
+    ?sql_comp_assert("SHOW CREATE TABLE \"GeoCheckins\"", show_create_table,
+        [{identifier, <<"GeoCheckins">>}]).


### PR DESCRIPTION
https://bashoeng.atlassian.net/browse/RTS-1403

This feature returns the SQL necessary to recreate a table from scratch as well as many of the bucket properties.  Some of the internal properties have been filtered out.  The command is simply
`SHOW CREATE TABLE <tablename>`.

The module `riak_ql_to_string` was altered to have all SQL keywords be upper case (it was previously inconsistent) and the option for a multiline output which is much more human-readable, especially inside of `riak_shell`.  The `WITH` clause was added to the output of `riak_ql_to_string:ddl_rec_to_sql` to reveal the bucket properties.