### PR TITLE
Revert key values for timestamps that are DESC ordered

### DIFF
--- a/src/riak_ql_ddl_compiler.erl
+++ b/src/riak_ql_ddl_compiler.erl
@@ -342,6 +342,9 @@ revert_ordering_on_local_key_element(DDL, ?SQL_PARAM{ name = N1, ordering = desc
         sint64 ->
             %% in the case of integers we just negate the original negation
             N2 ++ "*-1";
+        timestamp ->
+            %% in the case of integers we just negate the original negation
+            N2 ++ "*-1";
         _ ->
             N2
     end;
@@ -1168,6 +1171,18 @@ build_revert_ordering_on_local_key_fn_string_test() ->
         "PRIMARY KEY ((a,b,quantum(c, 15, 's')), a ASC,b DESC,c ASC))")),
     ?assertEqual(
         "revert_ordering_on_local_key({A,B,C}) -> [A,riak_ql_ddl:flip_binary(B),C].",
+        build_revert_ordering_on_local_key_fn_string(DDL)
+    ).
+
+build_revert_ordering_on_local_key_fn_string_timestamp_test() ->
+    {ddl, DDL, _} = riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+        "CREATE TABLE temperatures ("
+        "a VARCHAR NOT NULL, "
+        "b TIMESTAMP NOT NULL, "
+        "c TIMESTAMP NOT NULL, "
+        "PRIMARY KEY ((a,b,quantum(c, 15, 's')), a ASC,b DESC,c ASC))")),
+    ?assertEqual(
+        "revert_ordering_on_local_key({A,B,C}) -> [A,B*-1,C].",
         build_revert_ordering_on_local_key_fn_string(DDL)
     ).
 

--- a/src/riak_ql_show_create_table.erl
+++ b/src/riak_ql_show_create_table.erl
@@ -30,7 +30,7 @@
 
 %%
 -spec show_create_table(?DDL{}, [tuple()]) -> {ok, {ColNames::[binary()],
-                                               ColTypes::[riak_ql_ddl:simple_field_type()],
+                                               ColTypes::[riak_ql_ddl:external_field_type()],
                                                Rows::[[any()]]}}.
 
 show_create_table(DDL, Props) ->


### PR DESCRIPTION
Local keys that had a timestamp value with `DESC` sort order, were not being reverted before they were sent back using streaming list keys. This PR now reverts the value to it's original.