### PR TITLE
Put Filters on Local Key Columns in the Query Keys is possible

### DIFF
--- a/test/parser_select_tests.erl
+++ b/test/parser_select_tests.erl
@@ -489,3 +489,17 @@ single_line_comment_in_multiline_ctrl_select_test() ->
             "SELECT * FROM mytab -- a comment\r\n"
             "WHERE a = 'val'"))
     ).
+
+single_line_comment_single_line_in_multiline_comment_select_test() ->
+    ?assertEqual(
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE a = 'val'")),
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "/*\n"
+            "Some text -- */\n"
+            "*/\n"
+            "WHERE a = 'val'"))
+    ).
+

--- a/test/parser_select_tests.erl
+++ b/test/parser_select_tests.erl
@@ -490,16 +490,17 @@ single_line_comment_in_multiline_ctrl_select_test() ->
             "WHERE a = 'val'"))
     ).
 
-single_line_comment_single_line_in_multiline_comment_select_test() ->
-    ?assertEqual(
-        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
-            "SELECT * FROM mytab "
-            "WHERE a = 'val'")),
-        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
-            "SELECT * FROM mytab "
-            "/*\n"
-            "Some text -- */\n"
-            "*/\n"
-            "WHERE a = 'val'"))
-    ).
+% FIXME RTS-1546
+% single_line_comment_single_line_in_multiline_comment_select_test() ->
+%     ?assertEqual(
+%         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+%             "SELECT * FROM mytab "
+%             "WHERE a = 'val'")),
+%         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+%             "SELECT * FROM mytab "
+%             "/*\n"
+%             "Some text -- */\n"
+%             "*/\n"
+%             "WHERE a = 'val'"))
+%     ).
 


### PR DESCRIPTION
Optimise queries by putting filters that test equality of columns in the local key but not in the partition key, in the star and end key.

```sql
PRIMARY KEY((quantum(a,1,'m')),a,b)

SELECT * FROM table WHERE a > 2 and a < 6 AND b = 5
```

Instead of putting b just in the filter, put it in the start and end keys. This narrows the range from everything between `{2,_}` and `{6,_}` to everything between `{2,5}` and `{6,5}`.

For equality filters, it is not safe to remove the filter, because {3,7} is also in the range but should not be returned because only rows where b = 5 are correct for this query.

In this PR only the equality `=` operator is checked, to make this change a little smaller.

Depends on https://github.com/basho/riak_kv/pull/1559