### PR TITLE
new fun riak_ql_ddl:desc_adjusted_key/3, for consumers in riak_kv_ts_api

### DIFF
--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -202,11 +202,12 @@ negate_if_desc(KeyVals, Mod, ?DDL{local_key = #key_v1{ast = LKAst} = LK})
             {error, {bad_key_length, Got, Need}}
     end.
 
--spec lk_to_pk(tuple(), ?DDL{}) -> tuple().
+-spec lk_to_pk([bare_data_value()], ?DDL{}) -> {ok, [bare_data_value()]} |
+                                   {error, {bad_key_length, integer(), integer()}}.
 lk_to_pk(LKVals, DDL = ?DDL{table = Table}) ->
     lk_to_pk(LKVals, make_module_name(Table), DDL).
 
--spec lk_to_pk([any()], module(), ?DDL{}) -> {ok, [any()]} |
+-spec lk_to_pk([bare_data_value()], module(), ?DDL{}) -> {ok, [bare_data_value()]} |
                                              {error, {bad_key_length, integer(), integer()}}.
 %% @doc Determine the partition key of the quantum where given local
 %%      key resides, observing DESC qualifiers where appropriate.
@@ -1162,8 +1163,8 @@ make_ts_keys_1_test() ->
         "c TIMESTAMP NOT NULL, "
         "PRIMARY KEY((a, b, quantum(c, 15, 's')), a, b, c))"),
     ?assertEqual(
-        {ok, {1,2,0}},
-        lk_to_pk({1,2,3}, DDL, Mod)
+        {ok, [1,2,0]},
+        lk_to_pk([1,2,3], Mod, DDL)
     ).
 
 % a two element key, still using the table definition field order
@@ -1175,8 +1176,8 @@ make_ts_keys_2_test() ->
         "c SINT64 NOT NULL, "
         "PRIMARY KEY((a, quantum(b, 15, 's')), a, b))"),
     ?assertEqual(
-        {ok, {1,0}},
-        lk_to_pk({1,2}, DDL, Mod)
+        {ok, [1,0]},
+        lk_to_pk([1,2], Mod, DDL)
     ).
 
 make_ts_keys_3_test() ->
@@ -1188,8 +1189,8 @@ make_ts_keys_3_test() ->
         "d SINT64 NOT NULL, "
         "PRIMARY KEY  ((d,a,quantum(c, 1, 's')), d,a,c))"),
     ?assertEqual(
-        {ok, {10,20,0}},
-        lk_to_pk({10,20,1}, DDL, Mod)
+        {ok, [10,20,0]},
+        lk_to_pk([10,20,1], Mod, DDL)
     ).
 
 make_ts_keys_4_test() ->
@@ -1202,8 +1203,8 @@ make_ts_keys_4_test() ->
         "d SINT64 NOT NULL, "
         "PRIMARY KEY  ((ax,a,quantum(c, 1, 's')), ax,a,c))"),
     ?assertEqual(
-        {ok, {10,20,0}},
-        lk_to_pk({10,20,1}, DDL, Mod)
+        {ok, [10,20,0]},
+        lk_to_pk([10,20,1], Mod, DDL)
     ).
 
 %%

--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -27,7 +27,6 @@
          apply_ordering/2,
          convert/2,
          current_version/0,
-         negate_if_desc/3,
          ddl_record_version/1,
          first_version/0,
          flip_binary/1,
@@ -186,28 +185,6 @@ get_local_key(?DDL{table = T}=DDL, Obj)
     Mod = make_module_name(T),
     get_local_key(DDL, Obj, Mod).
 
--spec negate_if_desc([bare_data_value()], module(), ?DDL{}) ->
-                               {ok, [bare_data_value()]} | {error, {bad_key_length, integer(), integer()}}.
-%% @doc Given a list of Key values, negate values of fields declared
-%%      in the DDL as DESC, thus making the result match the key in
-%%      the backend.  Used in KeyConvFn for folding over keys (in
-%%      riak_kv_qry_worker:make_key_conversion_fun and
-%%      riak_kv_ts_svc:sub_tslistkeysreq), and in
-%%      riak_kv_ts_api:get_data and :delete_data.
-negate_if_desc(KeyVals, Mod, ?DDL{local_key = #key_v1{ast = LKAst} = LK})
-  when is_list(KeyVals) ->
-    KeyFields = [F || ?SQL_PARAM{name = [F]} <- LKAst],
-    case {length(KeyVals), length(KeyFields)} of
-        {_N, _N} ->
-            LKPairs = lists:zip(KeyFields, KeyVals),
-            {_Types, Vals} =
-                lists:unzip(
-                  riak_ql_ddl:make_key(Mod, LK, LKPairs)),
-            {ok, Vals};
-        {Got, Need} ->
-            {error, {bad_key_length, Got, Need}}
-    end.
-
 -spec lk_to_pk([bare_data_value()], ?DDL{}) -> {ok, [bare_data_value()]} |
                                    {error, {bad_key_length, integer(), integer()}}.
 lk_to_pk(LKVals, DDL = ?DDL{table = Table}) ->
@@ -217,7 +194,6 @@ lk_to_pk(LKVals, DDL = ?DDL{table = Table}) ->
                                              {error, {bad_key_length, integer(), integer()}}.
 %% @doc Determine the partition key of the quantum where given local
 %%      key resides, observing DESC qualifiers where appropriate.
-%%      Also see @see negate_if_desc/3.
 lk_to_pk(LKVals, Mod, ?DDL{local_key = #key_v1{ast = LKAst},
                            partition_key = PK}) ->
     KeyFields = [F || ?SQL_PARAM{name = [F]} <- LKAst],


### PR DESCRIPTION
Required by https://github.com/basho/riak_kv/pull/1560.

Provide a function to adjust key values for any DESC fields, for consumers in riak_kv_ts_api.

This is to fix regressions currently seen in `ts_simple_single_key_ops` (and possibly others).