### PR TITLE
Use query filters in start/end key RTS-1510

### DIFF
--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -550,11 +550,13 @@ fold_where_tree2(_, Fn, Acc1, {Op, LHS, RHS}) when Op == and_; Op == or_ ->
 fold_where_tree2(Conditional, Fn, Acc, Clause) ->
     Fn(Conditional, Clause, Acc).
 
-mapfold_where_tree(Fn, Acc, Where) when is_function(Fn) ->
-    case mapfold_where_tree2(root, Fn, Acc, Where) of
-        {eliminate, Acc} ->
-            {[], Acc};
-        Return ->
+mapfold_where_tree(_, Acc1, []) ->
+    {[], Acc1};
+mapfold_where_tree(Fn, Acc1, Where) when is_function(Fn) ->
+    case mapfold_where_tree2(root, Fn, Acc1, Where) of
+        {eliminate, Acc2} ->
+            {[], Acc2};
+        {_,_} = Return ->
             Return
     end.
 

--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -550,6 +550,15 @@ fold_where_tree2(_, Fn, Acc1, {Op, LHS, RHS}) when Op == and_; Op == or_ ->
 fold_where_tree2(Conditional, Fn, Acc, Clause) ->
     Fn(Conditional, Clause, Acc).
 
+%% Like lists:mapfoldl but specifically for where clause AST. The fun will be
+%% called on each filter e.g. `Fun(Conditional, Filter, Acc)`. 
+%% * Conditional is either `_and`, `_or` or `root`.
+%% * Filter AST tuple
+%% * Acc is the provided accumulator
+%%
+%% The fun should return a tuple like `{MappedFilter,Acc2}`. Special returns for
+%% `MappedValue are `eliminate` which removes the filter and skip which skips
+%% this filter and any more in the same branch. 
 mapfold_where_tree(_, Acc1, []) ->
     {[], Acc1};
 mapfold_where_tree(Fn, Acc1, Where) when is_function(Fn) ->

--- a/test/parser_select_tests.erl
+++ b/test/parser_select_tests.erl
@@ -489,3 +489,17 @@ single_line_comment_in_multiline_ctrl_select_test() ->
             "SELECT * FROM mytab -- a comment\r\n"
             "WHERE a = 'val'"))
     ).
+
+single_line_comment_single_line_in_multiline_comment_select_test() ->
+    ?assertEqual(
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "WHERE a = 'val'")),
+        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+            "SELECT * FROM mytab "
+            "/*\n"
+            "Some text -- */\n"
+            "*/\n"
+            "WHERE a = 'val'"))
+    ).
+

--- a/test/parser_select_tests.erl
+++ b/test/parser_select_tests.erl
@@ -490,16 +490,17 @@ single_line_comment_in_multiline_ctrl_select_test() ->
             "WHERE a = 'val'"))
     ).
 
-single_line_comment_single_line_in_multiline_comment_select_test() ->
-    ?assertEqual(
-        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
-            "SELECT * FROM mytab "
-            "WHERE a = 'val'")),
-        riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
-            "SELECT * FROM mytab "
-            "/*\n"
-            "Some text -- */\n"
-            "*/\n"
-            "WHERE a = 'val'"))
-    ).
+% FIXME RTS-1546
+% single_line_comment_single_line_in_multiline_comment_select_test() ->
+%     ?assertEqual(
+%         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+%             "SELECT * FROM mytab "
+%             "WHERE a = 'val'")),
+%         riak_ql_parser:ql_parse(riak_ql_lexer:get_tokens(
+%             "SELECT * FROM mytab "
+%             "/*\n"
+%             "Some text -- */\n"
+%             "*/\n"
+%             "WHERE a = 'val'"))
+%     ).
 


### PR DESCRIPTION
For https://github.com/basho/riak_kv/pull/1594

Exported `riak_ql_ddl:fold_where/3` and new function `riak_ql_ddl:mapfold_where`. These functions iterate down where clause AST filters.

