### PR TITLE
Add support for alter table with properties

### DIFF
--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -5,6 +5,7 @@
 
 Definitions.
 
+ALTER = (A|a)(L|l)(T|t)(E|e)(R|r)
 AND = (A|a)(N|n)(D|d)
 ASC = (A|a)(S|s)(C|c)
 BLOB = (B|b)(L|l)(O|o)(B|b)
@@ -85,6 +86,7 @@ SEMICOLON = (\;)
 
 Rules.
 
+{ALTER} : {token, {alter, list_to_binary(TokenChars)}}.
 {AND} : {token, {and_, list_to_binary(TokenChars)}}.
 {ASC} : {token, {asc, list_to_binary(TokenChars)}}.
 {BLOB} : {token, {blob, list_to_binary(TokenChars)}}.


### PR DESCRIPTION
Full alter table support will come later. This enables changing bucket properties only.