### PR TITLE
Fix field comparison error handling

### DIFF
--- a/src/riak_ql_ddl.erl
+++ b/src/riak_ql_ddl.erl
@@ -413,6 +413,9 @@ is_filters_field_valid(Mod, {Op, Field, {RHS_type1, RHS_Val}}, Acc1) when (Op ==
         false ->
             [{unexpected_where_field, Field} | Acc1]
     end;
+%% the case where two fields are being operated on
+is_filters_field_valid(_Mod, {_Op, _Field1, _Field2}, Acc1) when is_binary(_Field1), is_binary(_Field2) ->
+    [{invalid_field_operation} | Acc1];
 is_filters_field_valid(Mod, {_, Field, _}, Acc1) when is_binary(Field) ->
     case Mod:is_field_valid([Field]) of
         true  ->
@@ -429,9 +432,6 @@ is_filters_field_valid(Mod, {NullOp, {identifier, Field}}, Acc1) when NullOp =:=
         false ->
             [{unexpected_where_field, Field} | Acc1]
     end;
-%% the case where two fields are being operated on
-is_filters_field_valid(_Mod, {_Op, _Field1, _Field2}, Acc1) when is_binary(_Field1), is_binary(_Field2) ->
-    [{invalid_field_operation} | Acc1];
 %% the case where RHS is an expression on its own (LHS must still be a valid field)
 is_filters_field_valid(_, _, Acc1) ->
     Acc1.


### PR DESCRIPTION
Commit `ef5797938f7b445b80297a529b340003faa70f87` broke the logic that watched for two fields in a comparison `(myfamily=myseries)` and reported a sensible error.

It did so by introducing a new function head. This change re-orders function heads.